### PR TITLE
Document workflow for changes to working drafts

### DIFF
--- a/Workflow.md
+++ b/Workflow.md
@@ -42,7 +42,7 @@ number (for example `sarif-v1.0-wd02-provisional.docx`).
 
     1. Push the latest version of the change draft to the repo.
 
-           **NOTE**: This does *not* require a PR.
+       **NOTE**: This does *not* require a PR.
 
 1. If an issue requires further discussion at the next TC meeting, the Editors will:
 
@@ -53,13 +53,13 @@ number (for example `sarif-v1.0-wd02-provisional.docx`).
 
     1. Push the latest version of the change draft to the repo.
 
-           **NOTE**: This does *not* require a PR.
+       **NOTE**: This does *not* require a PR.
 
 1. If the TC approves a change (or one of a set of competing changes), the Editors will:
 
     1. Merge the changes from the approved change draft into the provisional draft, with change tracking enabled.
 
-           **NOTE**: We can use Word's "Combine documents" feature (on the Review tab of the ribbon) to accomplish this easily.
+       **NOTE**: We can use Word's "Combine documents" feature (on the Review tab of the ribbon) to accomplish this easily.
 
     1. Label the issue `resolved-fixed`.
 

--- a/Workflow.md
+++ b/Workflow.md
@@ -5,46 +5,93 @@ into the SARIF spec, and describes the workflow for incorporating agreed-upon ch
 
 # Principals and process
 
-* We encourage discussion on the public issues. The Editors will ensure that issues are
+1. We encourage discussion on the public issues. The Editors will ensure that issues are
 filed in the GitHub repo, and will "curate" them by applying issue labels, ensuring
-content from other sources (email) is recorded in the GitHub issue, etc.
+content from other sources (email) is recorded in the GitHub issue, _etc._
 
-* Any issues that require time-sensitive discussion will be driven through the mailing
+1. Any issues that require time-sensitive discussion will be driven through the mailing
 list (this should be rare).
 
-* Once a revision of the Working Draft has been accepted (for example,
+1. Once a revision of the Working Draft has been accepted (for example,
 `sarif-v1.0-wd01.docx`), the Editors will create a "provisional" draft with the next
-number, for example `sarif-v1.0-wd02-provisional.docx`.
+number (for example `sarif-v1.0-wd02-provisional.docx`).
 
-* The Editors will make all changes in the provisional copy, with change tracking enabled.
+1. When a change is proposed, the Editors will push a copy of the _current_ Working Draft
+    to the Drafts folder of the repo.
+    The copy will have a name of the form `sarif-issue-<issueNumber>-<mnemonic>.docx`.
+    We refer to this copy as a "change draft".
 
-* Issues that are ready for final approval or which warrant discussion on the telecon will
-be identified with the label `ready-for-approval`in advance of each meeting. The Editor
-will also add a comment to the provisional document stating that the proposal is ready.
+    **NOTE**: This does *not* require a PR.
 
-* After telecon approval/rejection, the Editors will "Accept" or "Reject" the relevant
-changes in the Word document, remove the relevant comments from the document, and close
-the GitHub issue, labeling it as either `resolved-fixed` or `resolved-wont-fix`.
+    The "mnemonic" is a short string (at most a few words) that distinguishes
+    this change from other, competing proposals that address the same issue.
+    For example, if there are two competing proposals to address Issue #&#xfeff;3,
+    there might be two change drafts:
 
-* At certain times, the TC might decide to capture the current state of the Working Draft
-in a _revised_ Working Draft (with the next revision number). In that case, the Editors
+    * `sarif-issue-3-multiple-classifications.docx`
+
+    * `sarif-issue-3-single-classification.docx`
+
+1. The Editors will make all changes in the change draft, with change tracking enabled.
+
+1. When an issue is ready for final approval, the Editors will:
+
+    1. Label the issue `ready-for-approval`.
+
+    1. Place a comment at the top of the change draft stating that the proposal is ready.
+
+    1. Push the latest version of the change draft to the repo.
+
+           **NOTE**: This does *not* require a PR.
+
+1. If an issue requires further discussion at the next TC meeting, the Editors will:
+
+    1. Label the issue `discussion-ongoing`.
+
+    1. Place a comment at the top of the change draft stating that the proposal requires
+    further discussion.
+
+1. If the TC approves a change (or one of a set of competing changes), the Editors will:
+
+    1. Transfer the changes from the approved change draft to the provisional draft, with change tracking enabled.
+
+    1. Label the issue `resolved-fixed`.
+
+    1. Close the issue.
+
+    1. Place a comment at the top of the approved change draft stating that the proposal was approved.
+
+    1. Place a comment at the top of any competing change draft stating that the proposal was rejected.
+
+1. If the TC rejects a change (or rejects every one of a set of competing changes),
+and if the TC further decides not to continue to address the issue, the Editors will:
+
+    1. Label the issue `resolved-wont-fix`.
+
+    1. Close the issue.
+
+    1. Place a comment at the top of every associated change draft stating that the proposal
+    was rejected.
+
+1. At certain times, the TC might decide to capture the current state of the provisional draft
+in a revised Working Draft (with the next revision number). In that case, the Editors
 will:
+
     1. Copy the provisional draft (say, `sarif-v1.0-wd02-provisional.docx`) to a file
-    with the correct name for the next "real" draft (in this example, copying
+    with the correct name for the next Working Draft (in this example, copying
     `sarif-v1.0-wd02-provisional.docx` to `sarif-v1.0-wd02.docx`).
 
-    2. _Revert all change-tracked changes, and remove all comments_ in the real draft
-    (because none of those changes will have been accepted yet.
+    2. Accept all change-tracked changes, and remove all comments.
 
-    3. Modify the metadata in the real draft so that the correct document identifier (in
+    3. Modify the document metadata so that the correct document identifier (in
     this example, `sarif-v1.0-wd02`) appears in the document footer.
 
-    4. Rename the “provisional” draft to the next version number (in this example,
+    4. Rename the provisional draft to the next version number (in this example,
     renaming `sarif-v1.0-wd02-provisional.docx` to `sarif-v1.0-wd03-provisional.docx`).
 
-* This process will be documented in the file `Workflow.md` in the repository.
+1. This process will be documented in the file `Workflow.md` in the repository.
 
-* Changes to this process will be requested by opening an issue in the repository, and
+1. Changes to this process will be requested by opening an issue in the repository, and
   must be approved at a TC meeting.
 
 # Issue labels
@@ -63,6 +110,7 @@ These labels are mostly a subset of the labels in the [original spec repo](https
 - `process`: The issue relates to the process of producing the TC's work products, rather than to the content of the work products themselves.
 - `prototype-needed`: The practicality of implementing the proposed change is unclear; the change should be prototyped in code before being considered for adoption.
 - `question`: The issue is a request for information, not a proposal to change the format or the documentation.
+- `discussion-ongoing`: The issue requires further discussion at the next TC meeting.
 - `ready-for-approval`: The issue has been discussed and a resolution reached, the spec has been edited with change tracking to reflect the change, and the change is ready for approval at the next TC meeting.
 - `resolved-by-design`: If the issue is a bug, this label means that the existing behavior is as intended and will not be changed.
 - `resolved-deferred`: The issue is deferred for consideration in a future version of the specification.

--- a/Workflow.md
+++ b/Workflow.md
@@ -42,7 +42,7 @@ number (for example `sarif-v1.0-wd02-provisional.docx`).
 
     1. Push the latest version of the change draft to the repo.
 
-           **NOTE**: This does *not* require a PR.
+       **NOTE**: This does *not* require a PR.
 
 1. If an issue requires further discussion at the next TC meeting, the Editors will:
 
@@ -77,16 +77,16 @@ and if the TC further decides not to continue to address the issue, the Editors 
 in a revised Working Draft (with the next revision number). In that case, the Editors
 will:
 
-    1. Copy the provisional draft (say, `sarif-v1.0-wd02-provisional.docx`) to a file
-    with the correct name for the next Working Draft (in this example, copying
-    `sarif-v1.0-wd02-provisional.docx` to `sarif-v1.0-wd02.docx`).
+    1. Accept all change-tracked changes in the provisional draft
+    (for example, `sarif-v1.0-wd02-provisional.docx`), and remove all comments.
+    
+    1. Modify the document metadata in the provisional draft so that the correct document identifier
+    (in this example, `sarif-v1.0-wd02`) appears in the document footer.
 
-    2. Accept all change-tracked changes, and remove all comments.
+    1. Copy the provisional draft  to a file with the correct name for the next Working Draft
+    (in this example, copying `sarif-v1.0-wd02-provisional.docx` to `sarif-v1.0-wd02.docx`).
 
-    3. Modify the document metadata so that the correct document identifier (in
-    this example, `sarif-v1.0-wd02`) appears in the document footer.
-
-    4. Rename the provisional draft to the next version number (in this example,
+    1. Rename the provisional draft to the next version number (in this example,
     renaming `sarif-v1.0-wd02-provisional.docx` to `sarif-v1.0-wd03-provisional.docx`).
 
 1. This process will be documented in the file `Workflow.md` in the repository.

--- a/Workflow.md
+++ b/Workflow.md
@@ -39,8 +39,7 @@ will:
     4. Rename the “provisional” draft to the next version number (in this example,
     renaming `sarif-v1.0-wd02-provisional.docx` to `sarif-v1.0-wd03-provisional.docx`).
 
-* This process (with additional details) will be documented in the file `Workflow.md` in
-  the repository.
+* This process will be documented in the file `Workflow.md` in the repository.
 
 * Changes to this process will be requested by opening an issue in the repository, and
   must be approved at a TC meeting.

--- a/Workflow.md
+++ b/Workflow.md
@@ -1,5 +1,9 @@
+#Introduction
+
 This document presents the principles that govern how the SARIF TC incorporates changes
 into the SARIF spec, and describes the workflow for incorporating agreed-upon changes.
+
+#Principals and process
 
 * We encourage discussion on the public issues. The Editors will ensure that issues are
 filed in the GitHub repo, and will "curate" them by applying issue labels, ensuring
@@ -15,7 +19,7 @@ number, for example `sarif-v1.0-wd02-provisional.docx`.
 * The Editors will make all changes in the provisional copy, with change tracking enabled.
 
 * Issues that are ready for final approval or which warrant discussion on the telecon will
-be identified with the label `ready-for-review`in advance of each meeting. Relevant
+be identified with the label `ready-for-approval`in advance of each meeting. Relevant
 tracked changes and open comments in the current provisional working draft will also
 reflect this status.
 
@@ -43,3 +47,25 @@ will:
 
 * Changes to this process will be requested by opening an issue in the repository, and
   must be approved at a TC meeting.
+
+#Issue labels
+We will track the workflow status of issues in the repo with a set of labels.
+These labels are mostly a subset of the tags in the [original spec repo](https://github.com/sarif-standard/sarif-spec):
+
+- `bug`: The issue prevents the file format from correctly and consistently representing the information necessary to support the scenarios for which it is designed.
+- `enhancement`: The proposal adds support to the spec for a new scenario, or provide richer support for a supported scenario.
+- `domain-result-management`: The issue is specific to the domain of result management.
+- `domain-security`: The issue is specific to the security domain.
+- `impact-breaks-consumers`: The proposed change to the format would prevent consumers of the format, such as viewers or result management systems, from consuming some or all valid log files.
+- `impact-breaks-producers`: The proposed change to the format would render invalid log files created by existing producers, such as analysis tools or converters.
+- `impact-documentation-only`: The proposed change clarifies or enhances the documentation, but does not affect the format.
+- `impact-non-breaking-change`: The proposed change to the format is backward compatible with all conforming producers and consumers.
+- `process`: The issue relates to the process of producing the TC's work products, rather than to the content of the work products themselves.
+- `prototype-needed`: The practicality of implementing the proposed change is unclear; the change should be prototyped in code before being considered for adoption.
+- `question`: The issue is a request for information, not a proposal to change the format or the documentation.
+- `ready-for-approval`: The issue has been discussed and a resolution reached, the spec has been edited with change tracking to reflect the change, and the change is ready for approval at the next TC meeting.
+- `resolved-by-design`: If the issue is a bug, this tag means that the existing behavior is as intended and will not be changed.
+- `resolved-deferred`: The issue is deferred for consideration in a future version of the specification.
+- `resolved-duplicate`: The issue is a duplicate of another.
+- `resolved-fixed`: The changes to the spec have been approved at a TC meeting and have been merged into the Working Draft.
+- `resolved-wont-fix`: If the issue is a bug, this tag means that the bug will not be fixed. (This should be rare!) If the issue is an enhancement, this tag means that the TC has decided not to incorporate the proposed change into the spec.

--- a/Workflow.md
+++ b/Workflow.md
@@ -51,7 +51,7 @@ will:
 # Issue labels
 
 We will track the workflow status of issues in the repo with a set of labels.
-These labels are mostly a subset of the tags in the [original spec repo](https://github.com/sarif-standard/sarif-spec):
+These labels are mostly a subset of the labels in the [original spec repo](https://github.com/sarif-standard/sarif-spec):
 
 - `bug`: The issue prevents the file format from correctly and consistently representing the information necessary to support the scenarios for which it is designed.
 - `enhancement`: The proposal adds support to the spec for a new scenario, or provide richer support for a supported scenario.
@@ -65,8 +65,8 @@ These labels are mostly a subset of the tags in the [original spec repo](https:/
 - `prototype-needed`: The practicality of implementing the proposed change is unclear; the change should be prototyped in code before being considered for adoption.
 - `question`: The issue is a request for information, not a proposal to change the format or the documentation.
 - `ready-for-approval`: The issue has been discussed and a resolution reached, the spec has been edited with change tracking to reflect the change, and the change is ready for approval at the next TC meeting.
-- `resolved-by-design`: If the issue is a bug, this tag means that the existing behavior is as intended and will not be changed.
+- `resolved-by-design`: If the issue is a bug, this label means that the existing behavior is as intended and will not be changed.
 - `resolved-deferred`: The issue is deferred for consideration in a future version of the specification.
 - `resolved-duplicate`: The issue is a duplicate of another.
 - `resolved-fixed`: The changes to the spec have been approved at a TC meeting and have been merged into the Working Draft.
-- `resolved-wont-fix`: If the issue is a bug, this tag means that the bug will not be fixed. (This should be rare!) If the issue is an enhancement, this tag means that the TC has decided not to incorporate the proposed change into the spec.
+- `resolved-wont-fix`: If the issue is a bug, this label means that the bug will not be fixed. (This should be rare!) If the issue is an enhancement, this label means that the TC has decided not to incorporate the proposed change into the spec.

--- a/Workflow.md
+++ b/Workflow.md
@@ -19,9 +19,8 @@ number, for example `sarif-v1.0-wd02-provisional.docx`.
 * The Editors will make all changes in the provisional copy, with change tracking enabled.
 
 * Issues that are ready for final approval or which warrant discussion on the telecon will
-be identified with the label `ready-for-approval`in advance of each meeting. Relevant
-tracked changes and open comments in the current provisional working draft will also
-reflect this status.
+be identified with the label `ready-for-approval`in advance of each meeting. The Editor
+will also add a comment to the provisional document stating that the proposal is ready.
 
 * After telecon approval/rejection, the Editors will "Accept" or "Reject" the relevant
 changes in the Word document, remove the relevant comments from the document, and close

--- a/Workflow.md
+++ b/Workflow.md
@@ -42,7 +42,7 @@ number (for example `sarif-v1.0-wd02-provisional.docx`).
 
     1. Push the latest version of the change draft to the repo.
 
-       **NOTE**: This does *not* require a PR.
+           **NOTE**: This does *not* require a PR.
 
 1. If an issue requires further discussion at the next TC meeting, the Editors will:
 
@@ -53,11 +53,13 @@ number (for example `sarif-v1.0-wd02-provisional.docx`).
 
     1. Push the latest version of the change draft to the repo.
 
-       **NOTE**: This does *not* require a PR.
+           **NOTE**: This does *not* require a PR.
 
 1. If the TC approves a change (or one of a set of competing changes), the Editors will:
 
-    1. Transfer the changes from the approved change draft to the provisional draft, with change tracking enabled.
+    1. Merge the changes from the approved change draft into the provisional draft, with change tracking enabled.
+
+           **NOTE**: We can use Word's "Combine documents" feature (on the Review tab of the ribbon) to accomplish this easily.
 
     1. Label the issue `resolved-fixed`.
 

--- a/Workflow.md
+++ b/Workflow.md
@@ -1,9 +1,9 @@
-#Introduction
+# Introduction
 
 This document presents the principles that govern how the SARIF TC incorporates changes
 into the SARIF spec, and describes the workflow for incorporating agreed-upon changes.
 
-#Principals and process
+# Principals and process
 
 * We encourage discussion on the public issues. The Editors will ensure that issues are
 filed in the GitHub repo, and will "curate" them by applying issue labels, ensuring
@@ -48,7 +48,8 @@ will:
 * Changes to this process will be requested by opening an issue in the repository, and
   must be approved at a TC meeting.
 
-#Issue labels
+# Issue labels
+
 We will track the workflow status of issues in the repo with a set of labels.
 These labels are mostly a subset of the tags in the [original spec repo](https://github.com/sarif-standard/sarif-spec):
 

--- a/Workflow.md
+++ b/Workflow.md
@@ -51,6 +51,10 @@ number (for example `sarif-v1.0-wd02-provisional.docx`).
     1. Place a comment at the top of the change draft stating that the proposal requires
     further discussion.
 
+    1. Push the latest version of the change draft to the repo.
+
+       **NOTE**: This does *not* require a PR.
+
 1. If the TC approves a change (or one of a set of competing changes), the Editors will:
 
     1. Transfer the changes from the approved change draft to the provisional draft, with change tracking enabled.

--- a/Workflow.md
+++ b/Workflow.md
@@ -1,0 +1,46 @@
+This document presents the principles that govern how the SARIF TC incorporates changes
+into the SARIF spec, and describes the workflow for incorporating agreed-upon changes.
+
+* We encourage discussion on the public issues. The Editors will ensure that issues are
+filed in the GitHub repo, and will "curate" them by applying issue labels, ensuring
+content from other sources (email) is recorded in the GitHub issue, etc.
+
+* Any issues that require time-sensitive discussion will be driven through the mailing
+list (this should be rare).
+
+* Once a revision of the Working Draft has been accepted (for example,
+`sarif-v1.0-wd01.docx`), the Editors will create a "provisional" draft with the next
+number, for example `sarif-v1.0-wd02-provisional.docx`.
+
+* The Editors will make all changes in the provisional copy, with change tracking enabled.
+
+* Issues that are ready for final approval or which warrant discussion on the telecon will
+be identified with the label `ready-for-review`in advance of each meeting. Relevant
+tracked changes and open comments in the current provisional working draft will also
+reflect this status.
+
+* After telecon approval/rejection, the Editors will "Accept" or "Reject" the relevant
+changes in the Word document, remove the relevant comments from the document, and close
+the GitHub issue, labeling it as either `resolved-fixed` or `resolved-wont-fix`.
+
+* At certain times, the TC might decide to capture the current state of the Working Draft
+in a _revised_ Working Draft (with the next revision number). In that case, the Editors
+will:
+    1. Copy the provisional draft (say, `sarif-v1.0-wd02-provisional.docx`) to a file
+    with the correct name for the next "real" draft (in this example, copying
+    `sarif-v1.0-wd02-provisional.docx` to `sarif-v1.0-wd02.docx`).
+
+    2. _Revert all change-tracked changes, and remove all comments_ in the real draft
+    (because none of those changes will have been accepted yet.
+
+    3. Modify the metadata in the real draft so that the correct document identifier (in
+    this example, `sarif-v1.0-wd02`) appears in the document footer.
+
+    4. Rename the “provisional” draft to the next version number (in this example,
+    renaming `sarif-v1.0-wd02-provisional.docx` to `sarif-v1.0-wd03-provisional.docx`).
+
+* This process (with additional details) will be documented in the file `Workflow.md` in
+  the repository.
+
+* Changes to this process will be requested by opening an issue in the repository, and
+  must be approved at a TC meeting.


### PR DESCRIPTION
This is the workflow we agreed on, with a few tweaks that I submit for your consideration:

1. The original proposal said:

> Issues that are ready for final approval or which warrant discussion on the telecon will
be tagged advance of each meeting.

I changed that to:

> Issues that are ready for final approval or which warrant discussion on the telecon will
be identified with the label `ready-for-approval` in advance of each meeting. 

2. A question: The proposal says:

>  Relevant tracked changes and open comments in the current provisional working draft will also reflect this status.

What does that mean? How do I make a "tracked change" reflect the "ready for review" status? And do we add the words "ready for review" to each relevant comment?

I suggest we remove this sentence.

3. The original proposal said:

> This process (with additional details) will be driven by an open issue and documented in a file persisted to the repository (and will be approved at the next TC meeting).

I changed that to:

> * This process will be documented in the file `Workflow.md` in the repository.
>
> * Changes to this process will be requested by opening an issue in the repository, and must be approved at a TC meeting.

4. I changed "tag" to "label" everywhere (GitHub calls them labels).

NOTE: I also included, at the end of the document, the list of issue labels I proposed in issue #2.