### PR TITLE
Deleted required property 'fullyQualifiedLogicalName' from stackFrame…

### DIFF
--- a/Documents/CommitteeSpecificationDrafts/CSD.1/sarif-schema.json
+++ b/Documents/CommitteeSpecificationDrafts/CSD.1/sarif-schema.json
@@ -1818,9 +1818,7 @@
             }
           }
         }
-      },
-
-      "required": [ "fullyQualifiedLogicalName" ]
+      }
     },
 
     "threadFlow": {

--- a/Schemata/sarif-schema.json
+++ b/Schemata/sarif-schema.json
@@ -1818,9 +1818,7 @@
             }
           }
         }
-      },
-
-      "required": [ "fullyQualifiedLogicalName" ]
+      }
     },
 
     "threadFlow": {


### PR DESCRIPTION
This is a proposed fix to Issue #225.