### PR TITLE
Create a to-do list to keep track of where we are

### DIFF
--- a/Plans.md
+++ b/Plans.md
@@ -1,0 +1,33 @@
+<div>
+<h2>Current Plan</h2>
+<p>The current plan is to advance SARIF v2.1.0 to OASIS Standard.</p>
+</div>
+<div>
+<h3>Next Steps</h3>
+<ul>
+<li>Three Statements of Use (SoU) are needed, one of which must be from an OASIS organizational member.  We currently have one SoU from a non-organizational member.</li>
+<li>A short (probably one paragraph) statement is needed comparing/contrasting SARIF with one or two other standards, to show where we fit into the ecosystem relative to others.  This statement will be presented as part of the application for Candidate OASIS Standard.</li>
+</ul>
+<p>Once the above steps are completed, we can move forward with an e-ballot for the following.</p>
+<ul>
+<li>Certification by the TC that all schema and XML instances are well-formed and that expressions are valid</li>
+<li>Approval of the descriptive and compare/contrast paragraphs</li>
+<li>Approval of the Statements of Use</li>
+<li>Request for Special Majority Vote to proceed to Candidate OASIS Standard</li>
+</ul>
+<p>Further steps after that are as follows.</p>
+<ol>
+<li>Special Majority Vote for Candidate OASIS Standard (approx. 2 weeks for the administration plus the vote)</li>
+<li>60-day public comment period for Candidate OASIS Standard</li>
+<li>Address any comments received from the comment period (non-material changes only)</li>
+<li>Hold an e-ballot to approve the changes and ask for a Call for Consent for OASIS Standard</li>
+<li>Call for Consent (approx. three weeks for admin plus vote)</li>
+<li>If no objections are received, publication of OASIS Standard (approx. 17 weeks after step 1 starts)</li>
+</ol>
+</div>
+<div>
+<h2>Potential Future Plans</h2>
+<ul>
+<li>Publish Errata or a new SARIF v2.1.1 to address any material changes deemed necessary</li>
+<li>Consider whether to address dynamic analisis, and if so, whether it should be part of SARIF or a separate standard</li>
+</ul>


### PR DESCRIPTION
Now that we are not having regular meetings, it is easy for people to forget where we are in the process.  This change adds a file to keep track of that information so people can always see at a glance what needs to be done next, and a rough estimate of how long it should take to reach the next goal.