### PR TITLE
Fix regex in language and locale recognition

### DIFF
--- a/Schemata/sarif-schema-2.1.0.json
+++ b/Schemata/sarif-schema-2.1.0.json
@@ -2354,7 +2354,7 @@
           "description": "The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase culture code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).",
           "type": "string",
           "default": "en-US",
-          "pattern": "^[a-zA-Z]{2}|^[a-zA-Z]{2}-[a-zA-Z]{2}]?$"
+          "pattern": "^[a-zA-Z]{2}(-[a-zA-Z]{2})?$"
         },
 
         "versionControlProvenance": {
@@ -3060,7 +3060,7 @@
           "description": "The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase language code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).",
           "type": "string",
           "default": "en-US",
-          "pattern": "^[a-zA-Z]{2}|^[a-zA-Z]{2}-[a-zA-Z]{2}]?$"
+          "pattern": "^[a-zA-Z]{2}(-[a-zA-Z]{2})?$"
         },
 
         "contents": {


### PR DESCRIPTION
This was first mentioned in https://github.com/github/codeql-action/issues/418
Also, raised in #488.

The current regex has an extra `]` at the end. This means that schema validation will incorrectly validate strings that should be an error. For example, the following strings are valid according to the regex, but should not be valid:

```
/^[a-zA-Z]{2}|^[a-zA-Z]{2}-[a-zA-Z]{2}]?$/
ja-JP] true
ja- true
ja-J true
ja-j] true
```

cc: @lcartey