### PR TITLE
Meeting Notes 2022-01-13 SARIF TC no. 50

### DIFF
--- a/meeting_minutes/220113_SARIF_TC_50.md
+++ b/meeting_minutes/220113_SARIF_TC_50.md
@@ -21,7 +21,7 @@ TODO
 
 ## 1.4 Approval of agenda (Co-Chair David) TODO
 
-* https://www.oasis-open.org/committees/download.php/acafe/agenda_20211209.html
+* https://www.oasis-open.org/committees/download.php/acafe/agenda_20220113.html
 
   Agenda was approved TODO
 

--- a/meeting_minutes/220113_SARIF_TC_50.md
+++ b/meeting_minutes/220113_SARIF_TC_50.md
@@ -7,7 +7,7 @@
 | First Name | Last Name | Company          | Role(s)                 |
 | :--------- | :-------- | :--------------- | :---------------------- |
 | Aditya     | Sharad    | Microsoft        | Member                  |
-| Chad       | Bentz     | defi SOLUTINS    | Public Participant      |
+| Courtney   | Lawton    | Microsoft        | Public Participant      |
 | David      | Keaton    | Individual       | Chair                   |
 | Eddy       | Nakamura  | Microsoft        | Voting member           |
 | James      | Spoor     | Snyk Ltd         | Member                  |
@@ -83,19 +83,27 @@
 
 ## 3.1 Review recruitment effort to complete the technical committee
 
-* One new member participating in the meeting today
+* David: One new member participating in the meeting today: James Spoor is welcomed
+* James: shortly introduced himself
+* Michael: Acquired a thechnical writer to assist in the production of the errata.
 
 ## 3.2 Review status on finalizing SARIF 2.1 errata
 
 * David: submitted the request to OASIS for the 15-day public review of the Errata on 2021-12-09.
+* Michael: There will be support to finalize the errata (technical writer)
+* David: Checklist for finalizing errata is in github issue [Requirements to finalize the errata #509](https://github.com/oasis-tcs/sarif-spec/issues/509)
 
 ## 3.3 Review current state of ecosystem ongoing work
 
-* TODO
+* Eddy:
+  - Github capabilities for SARIF extensions for VS and VSCode
+  - Improve Codeflows for tool (CodeQL)
+  - New ITM version
+* Michael: Highlighted the impact of some of these improvements 
 
 ## 3.4 Any continued report/discussion on metrics
 
-* TODO
+* ONGOING otherwise no updates from the committee
 
 ## 3.5 Review proposal for what's in- and out-of-scope - general discussion
 

--- a/meeting_minutes/220113_SARIF_TC_50.md
+++ b/meeting_minutes/220113_SARIF_TC_50.md
@@ -98,7 +98,7 @@
 * Eddy:
   - Github capabilities for SARIF extensions for VS and VSCode
   - Improve Codeflows for tool (CodeQL)
-  - New ITM version
+  - New RTM version (RTM 6)
 * Michael: Highlighted the impact of some of these improvements 
 
 ## 3.4 Any continued report/discussion on metrics

--- a/meeting_minutes/220113_SARIF_TC_50.md
+++ b/meeting_minutes/220113_SARIF_TC_50.md
@@ -46,7 +46,7 @@
 
 ### 1.7.1 Prospective members attending their first meeting
 
-* James Spoor first time participation
+* James Spoor first time participation amd if he attends the next meeting will gain voting rights at the end of that meeting.
 
 ### 1.7.2 Members attaining voting rights at the end of this meeting
 
@@ -123,10 +123,20 @@
 * All discuss options for a result store
 * Nathan: How does the envisaged result store handle static and dynamic analysis results
 * All discuss options for including dynamic results in a result store and to access per CIP 
+* Nathan: Shortly lists the typical activities and result types that his team performs and uses
+* David: Suggests to maybe consider eclipse to provide diversity of extensions
+* Paul: Suggests to be careful to decide on what "flavor" to target (as many vendors provide customized versions)
+* Stefan: Proposes to approach JetBrains - as they e.g. offer [Qodana - a linter with SARIF output](https://www.jetbrains.com/help/qodana/qodana-sarif-output.html) 
+* James: Maybe can present some of the Snyk tools in one of the next meetings
+* James: Consuming SARIF files can be resoruce intensive in the current version due to the format chosen - are there plans to change that or how do other tools handle that?
+* Michael: Mentions deferred reads and writes as well as compression (all code level solutions) exemplifying existing strategies used in the field to mitigate resource problems
+* Michael: Sketches some of the plans and the ideas not continued in the course of the existing spec version
+* Stefan: Is in favor of streamability but is afraid the resistance why we did design SARIF as a monolithic JSON object in the first place will be hard to overcome with chunked un-wrapped designs
+* All continue discussion
 
 # 4. Other Business
 
-* TODO
+* None
 
 # 5. Resolutions and Decisions reached (by 10 minutes prior to scheduled meeting end)
 
@@ -138,7 +148,10 @@
 
 ## 5.3 Review of Action Items (Secretary Stefan)
 
-* TODO
+* ACTION David: Find out how to upload content to wikipedia (#507)
+* ACTION Michael: Reach out to contacts at Google and Uber on the Code Insights Protocol topic
+* ACTION Michael: Reach out to ParaSoft
+* ACTION Michael: Will author and check in the roadmap / list of in- and out-of-scope features
 
 # 6. Next Meeting
 
@@ -146,4 +159,4 @@ January 27, 2022 / 08:00-09:30 PT / 16:00-17:30 UTC
 
 # 7. Adjournment
 
-Meeting was adjourned. TODO
+Meeting was adjourned.

--- a/meeting_minutes/220113_SARIF_TC_50.md
+++ b/meeting_minutes/220113_SARIF_TC_50.md
@@ -21,7 +21,7 @@ TODO
 
 ## 1.4 Approval of agenda (Co-Chair David) TODO
 
-* https://www.oasis-open.org/committees/download.php/acafe/agenda_20220113.html
+* https://www.oasis-open.org/committees/download.php/69500/agenda_20220113.html
 
   Agenda was approved TODO
 
@@ -62,6 +62,11 @@ TODO
   ```
   January 27
   ```
+* Proposed Teleconferences (Thursdays at 08:00 PT / 16:00 UTC for 1.5 hours)
+  ```
+  February 10
+  February 24
+  ```
 * Possible face-to-face meeting in 2022Q1
 
 # 3. Discussion
@@ -78,15 +83,15 @@ TODO
 
 * TODO
 
-## 3.4 Metrics: review CodeQL metrics design, and overall design strategy
+## 3.4 Any continued report/discussion on metrics
 
 * TODO
 
-## 3.5 Review proposal for what's in- and out-of-scope. General discussion
+## 3.5 Review proposal for what's in- and out-of-scope - general discussion
 
 * TODO
 
-## 3.6 Discuss next steps for working draft Wikipedia page
+## 3.6 Status of Wikipedia page
 
 * TODO
 

--- a/meeting_minutes/220113_SARIF_TC_50.md
+++ b/meeting_minutes/220113_SARIF_TC_50.md
@@ -31,32 +31,42 @@
 
   Minutes were approved
 
-## 1.6 Review of action items and resolutions (Secretary Stefan) TODO
+## 1.6 Review of action items and resolutions (Secretary Stefan)
 
 * ACTION David: Find out how to upload content to wikipedia (#507)
-  - TODO
+  - ONGOING
 * ACTION Michael: Reach out to contacts at Google and Uber on the Code Insights Protocol topic
-  - TODO
+  - ONGOING
 * ACTION Michael: Reach out to ParaSoft
-  - TODO
+  - ONGOING
 * ACTION Michael: Will author and check in the roadmap / list of in- and out-of-scope features
-  - TODO
+  - ONGOING
 
-## 1.7 Identification of SARIF TC voting members (Co-Chair David) TODO
+## 1.7 Identification of SARIF TC voting members (Co-Chair David)
 
-### 1.7.1 Prospective members attending their first meeting TODO
+### 1.7.1 Prospective members attending their first meeting
 
-### 1.7.2 Members attaining voting rights at the end of this meeting TODO
+* James Spoor first time participation
 
-### 1.7.3 Members losing voting rights if they have not joined this meeting by the time it ends TODO
+### 1.7.2 Members attaining voting rights at the end of this meeting
 
-### 1.7.4 Members who previously lost voting rights who are attending this meeting TODO
+* Aditya Sharad and Nathan Baird both will gain voting rights at the end of next meeting.
 
-### 1.7.5 Members who have declared a leave of absence TODO
+### 1.7.3 Members losing voting rights if they have not joined this meeting by the time it ends
+
+* None
+
+### 1.7.4 Members who previously lost voting rights who are attending this meeting
+
+* None
+
+### 1.7.5 Members who have declared a leave of absence
+
+* None
 
 # 2. Future Meetings
 
-## 2.1 Future meeting schedule (Co-Chair David) TODO
+## 2.1 Future meeting schedule (Co-Chair David)
 
 * Scheduled Teleconferences (Thursdays at 08:00 PT / 16:00 UTC for 1.5 hours)
   ```
@@ -73,7 +83,7 @@
 
 ## 3.1 Review recruitment effort to complete the technical committee
 
-* TODO
+* One new member participating in the meeting today
 
 ## 3.2 Review status on finalizing SARIF 2.1 errata
 
@@ -109,7 +119,7 @@
 
 ## 5.2 Review of Decisions Reached (Secretary Stefan)
 
-* DECISION: TODO
+* DECISION: Meetings agreed for February 10 and 24
 
 ## 5.3 Review of Action Items (Secretary Stefan)
 

--- a/meeting_minutes/220113_SARIF_TC_50.md
+++ b/meeting_minutes/220113_SARIF_TC_50.md
@@ -128,7 +128,7 @@
 * Paul: Suggests to be careful to decide on what "flavor" to target (as many vendors provide customized versions)
 * Stefan: Proposes to approach JetBrains - as they e.g. offer [Qodana - a linter with SARIF output](https://www.jetbrains.com/help/qodana/qodana-sarif-output.html) 
 * James: Maybe can present some of the Snyk tools in one of the next meetings
-* James: Consuming SARIF files can be resoruce intensive in the current version due to the format chosen - are there plans to change that or how do other tools handle that?
+* James: Consuming SARIF files can be resource intensive in the current version due to the format chosen - are there plans to change that or how do other tools handle that?
 * Michael: Mentions deferred reads and writes as well as compression (all code level solutions) exemplifying existing strategies used in the field to mitigate resource problems
 * Michael: Sketches some of the plans and the ideas not continued in the course of the existing spec version
 * Stefan: Is in favor of streamability but is afraid the resistance why we did design SARIF as a monolithic JSON object in the first place will be hard to overcome with chunked un-wrapped designs

--- a/meeting_minutes/220113_SARIF_TC_50.md
+++ b/meeting_minutes/220113_SARIF_TC_50.md
@@ -46,11 +46,11 @@
 
 ### 1.7.1 Prospective members attending their first meeting
 
-* James Spoor first time participation amd if he attends the next meeting will gain voting rights at the end of that meeting.
+* James Spoor first time participation and if he attends the next meeting will gain voting rights at the end of that meeting.
 
 ### 1.7.2 Members attaining voting rights at the end of this meeting
 
-* Aditya Sharad and Nathan Baird both will gain voting rights at the end of next meeting.
+* Aditya Sharad and Nathan Baird both will gain voting rights at the end of this meeting.
 
 ### 1.7.3 Members losing voting rights if they have not joined this meeting by the time it ends
 

--- a/meeting_minutes/220113_SARIF_TC_50.md
+++ b/meeting_minutes/220113_SARIF_TC_50.md
@@ -1,0 +1,119 @@
+# 1. Opening Activities
+
+## 1.1 Opening comments (Co-Chair David) TODO
+
+## 1.2 Introduction of participants/roll call (Co-Chair David) TODO
+
+| First Name | Last Name | Company          | Role(s)                 |
+| :--------- | :-------- | :--------------- | :---------------------- |
+| Aditya     | Sharad    | Microsoft        | Member                  |
+| Chad       | Bentz     | defi SOLUTINS    | Public Participant      |
+| David      | Keaton    | Individual       | Chair                   |
+| Eddy       | Nakamura  | Microsoft        | Voting member           |
+| Katrina    | O'Neil    | Micro Focus      | Voting member           |
+| Nathan     | Baird     | Microsoft        | Member                  |
+| Paul       | Anderson  | Grammatech, Inc. | Voting member           |
+| Stefan     | Hagen     | Individual       | Secretary, taking notes |
+
+TODO
+
+## 1.3 Procedures for this meeting (Co-Chair David) TODO
+
+## 1.4 Approval of agenda (Co-Chair David) TODO
+
+* https://www.oasis-open.org/committees/download.php/acafe/agenda_20211209.html
+
+  Agenda was approved TODO
+
+## 1.5 Approval of previous minutes (Co-Chair David) TODO
+
+* [Minutes of 2021-12-09 Meeting #48](https://www.oasis-open.org/committees/document.php?document_id=69499&wg_abbrev=sarif)
+
+  Minutes were approved TODO
+
+## 1.6 Review of action items and resolutions (Secretary Stefan) TODO
+
+* ACTION David: Find out how to upload content to wikipedia (#507)
+  - TODO
+* ACTION Michael: Reach out to contacts at Google and Uber on the Code Insights Protocol topic
+  - TODO
+* ACTION Michael: Reach out to ParaSoft
+  - TODO
+* ACTION Michael: Will author and check in the roadmap / list of in- and out-of-scope features
+  - TODO
+
+## 1.7 Identification of SARIF TC voting members (Co-Chair David) TODO
+
+### 1.7.1 Prospective members attending their first meeting TODO
+
+### 1.7.2 Members attaining voting rights at the end of this meeting TODO
+
+### 1.7.3 Members losing voting rights if they have not joined this meeting by the time it ends TODO
+
+### 1.7.4 Members who previously lost voting rights who are attending this meeting TODO
+
+### 1.7.5 Members who have declared a leave of absence TODO
+
+# 2. Future Meetings
+
+## 2.1 Future meeting schedule (Co-Chair David) TODO
+
+* Approved Teleconferences (Thursdays at 08:00 PT / 16:00 UTC for 1.5 hours)
+  ```
+  January 27
+  ```
+* Possible face-to-face meeting in 2022Q1
+
+# 3. Discussion
+
+## 3.1 Review recruitment effort to complete the technical committee
+
+* TODO
+
+## 3.2 Review status on finalizing SARIF 2.1 errata
+
+* David: submitted the request to OASIS for the 15-day public review of the Errata on 2021-12-09.
+
+## 3.3 Review current state of ecosystem ongoing work
+
+* TODO
+
+## 3.4 Metrics: review CodeQL metrics design, and overall design strategy
+
+* TODO
+
+## 3.5 Review proposal for what's in- and out-of-scope. General discussion
+
+* TODO
+
+## 3.6 Discuss next steps for working draft Wikipedia page
+
+* TODO
+
+## 3.7 Discuss end-to-end results management (including code insights protocol)
+
+* TODO
+
+# 4. Other Business
+
+* TODO
+
+# 5. Resolutions and Decisions reached (by 10 minutes prior to scheduled meeting end)
+
+## 5.1 End debate of other issues by 10 minutes prior to scheduled meeting end and follow the agenda from this point (Co-Chair David)
+
+## 5.2 Review of Decisions Reached (Secretary Stefan)
+
+* DECISION: TODO
+
+## 5.3 Review of Action Items (Secretary Stefan)
+
+* TODO
+
+# 6. Next Meeting
+
+January 27, 2022 / 08:00-09:30 PT / 16:00-17:30 UTC
+
+# 7. Adjournment
+
+Meeting was adjourned. TODO

--- a/meeting_minutes/220113_SARIF_TC_50.md
+++ b/meeting_minutes/220113_SARIF_TC_50.md
@@ -107,15 +107,22 @@
 
 ## 3.5 Review proposal for what's in- and out-of-scope - general discussion
 
-* TODO
+* ONGOING and tracked by Michael's action on the metrics / roadmap
 
 ## 3.6 Status of Wikipedia page
 
-* TODO
+* ONGOING and David plans to provide until one of the two next meetings
 
 ## 3.7 Discuss end-to-end results management (including code insights protocol)
 
-* TODO
+* Michael: Shortly mentions a risk from the differences in position sync of results and code locations in editors between VS (not available identically in VSCode)
+* Michael: New format ideas popped up to enable copy and paste transfer from GitHub CodeQL results into editor extensions
+* Michael: Ongoing internal discussion at Microsoft on fuzzing result transfer into extensions
+* Michael: Ongoing activities around the Code Insights Protocol (CIP)
+* Aditya: Offers support for the protocol to avoid duplication of efforts
+* All discuss options for a result store
+* Nathan: How does the envisaged result store handle static and dynamic analysis results
+* All discuss options for including dynamic results in a result store and to access per CIP 
 
 # 4. Other Business
 

--- a/meeting_minutes/220113_SARIF_TC_50.md
+++ b/meeting_minutes/220113_SARIF_TC_50.md
@@ -1,6 +1,6 @@
 # 1. Opening Activities
 
-## 1.1 Opening comments (Co-Chair David) TODO
+## 1.1 Opening comments (Co-Chair David)
 
 ## 1.2 Introduction of participants/roll call (Co-Chair David) TODO
 

--- a/meeting_minutes/220113_SARIF_TC_50.md
+++ b/meeting_minutes/220113_SARIF_TC_50.md
@@ -2,7 +2,7 @@
 
 ## 1.1 Opening comments (Co-Chair David)
 
-## 1.2 Introduction of participants/roll call (Co-Chair David) TODO
+## 1.2 Introduction of participants/roll call (Co-Chair David)
 
 | First Name | Last Name | Company          | Role(s)                 |
 | :--------- | :-------- | :--------------- | :---------------------- |
@@ -10,26 +10,26 @@
 | Chad       | Bentz     | defi SOLUTINS    | Public Participant      |
 | David      | Keaton    | Individual       | Chair                   |
 | Eddy       | Nakamura  | Microsoft        | Voting member           |
+| James      | Spoor     | Snyk Ltd         | Member                  |
 | Katrina    | O'Neil    | Micro Focus      | Voting member           |
 | Nathan     | Baird     | Microsoft        | Member                  |
 | Paul       | Anderson  | Grammatech, Inc. | Voting member           |
 | Stefan     | Hagen     | Individual       | Secretary, taking notes |
 
-TODO
 
-## 1.3 Procedures for this meeting (Co-Chair David) TODO
+## 1.3 Procedures for this meeting (Co-Chair David)
 
-## 1.4 Approval of agenda (Co-Chair David) TODO
+## 1.4 Approval of agenda (Co-Chair David)
 
 * https://www.oasis-open.org/committees/download.php/69500/agenda_20220113.html
 
-  Agenda was approved TODO
+  Agenda was approved
 
-## 1.5 Approval of previous minutes (Co-Chair David) TODO
+## 1.5 Approval of previous minutes (Co-Chair David)
 
 * [Minutes of 2021-12-09 Meeting #48](https://www.oasis-open.org/committees/document.php?document_id=69499&wg_abbrev=sarif)
 
-  Minutes were approved TODO
+  Minutes were approved
 
 ## 1.6 Review of action items and resolutions (Secretary Stefan) TODO
 

--- a/meeting_minutes/220113_SARIF_TC_50.md
+++ b/meeting_minutes/220113_SARIF_TC_50.md
@@ -58,7 +58,7 @@ TODO
 
 ## 2.1 Future meeting schedule (Co-Chair David) TODO
 
-* Approved Teleconferences (Thursdays at 08:00 PT / 16:00 UTC for 1.5 hours)
+* Scheduled Teleconferences (Thursdays at 08:00 PT / 16:00 UTC for 1.5 hours)
   ```
   January 27
   ```


### PR DESCRIPTION
This is the live pre-meeting version of the minutes draft for the 2022-01-13 meeting:

* [x] Current link for minutes approval of previous meeting (2021-12-09)
* [x] Current agenda link needs update when agenda draft link is available
* [x] Update table of participants during the roll call and the call for late joiners
* [x] Replace TODOs with actual minutes during the meeting
* [x] Update the decisions taken at the end of the meeting
* [x] Update the actions taken dito
* [x] Amend with post meeting draft revision
* [x] Ask for review and merge