### PR TITLE
Addition to minutes for voting membership

### DIFF
--- a/meeting_minutes/220210_SARIF_TC_52.md
+++ b/meeting_minutes/220210_SARIF_TC_52.md
@@ -45,6 +45,7 @@
 
 ### 1.7.2 Members attaining voting rights at the end of this meeting
 
+* Chris Meyer will gain voting rights at the end of this meeting
 * Arvid Paeglit will gain voting rights next meeting if he attends
 
 ### 1.7.3 Members losing voting rights if they have not joined this meeting by the time it ends


### PR DESCRIPTION
I failed to identify earlier that Chris Meyer had attended two meetings in a row and would gain voting privileges at the end of this meeting.  This change adds a note to that effect.  Chris has been updated to voting status now.