### PR TITLE
Add the guest and correct leave of absence status

### DIFF
--- a/meeting_minutes/221208_SARIF_TC_71.md
+++ b/meeting_minutes/221208_SARIF_TC_71.md
@@ -6,7 +6,8 @@
 
 | First Name | Last Name | Company           | Role(s)                         |
 |:-----------|:----------|:------------------|:--------------------------------|
-| Aditya     | Sharad    | Microsoft         | Voting Member, leave of absence |
+| Adar       | Weidman   | JFrog             | Guest (prospective member)      |
+| Aditya     | Sharad    | Microsoft         | Voting Member                   |
 | Charles    | Wilson    | Motional AD       | Voting Member                   |
 | David      | Keaton    | Individual        | Chair                           |
 | Gerald     | Sullivan  | Micro Focus       | Voting Member                   |


### PR DESCRIPTION
After merging the previous minutes, I found that I accidentally left out our guest attendee, and incorrectly reported Aditya's attendance status.  Those are now corrected.