### PR TITLE
Fix `language` pattern regex. `Lone quantifier brackets` error.

### DIFF
--- a/Documents/CommitteeSpecifications/2.1.0/sarif-schema-2.1.0.json
+++ b/Documents/CommitteeSpecifications/2.1.0/sarif-schema-2.1.0.json
@@ -2354,7 +2354,7 @@
           "description": "The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase culture code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).",
           "type": "string",
           "default": "en-US",
-          "pattern": "^[a-zA-Z]{2}|^[a-zA-Z]{2}-[a-zA-Z]{2}]?$"
+          "pattern": "^[a-zA-Z]{2}|^[a-zA-Z]{2}-[a-zA-Z]{2}?$"
         },
 
         "versionControlProvenance": {
@@ -3060,7 +3060,7 @@
           "description": "The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase language code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).",
           "type": "string",
           "default": "en-US",
-          "pattern": "^[a-zA-Z]{2}|^[a-zA-Z]{2}-[a-zA-Z]{2}]?$"
+          "pattern": "^[a-zA-Z]{2}|^[a-zA-Z]{2}-[a-zA-Z]{2}?$"
         },
 
         "contents": {


### PR DESCRIPTION
This PR fixes the `pattern` attribute of the `language`. The regex has a closing bracket in the end which does not correspond with any opening bracket. 

If you try to compile this JSON Schema (I did it using [ajv](https://github.com/ajv-validator/ajv)), the error will pop-up.