### PR TITLE
Allowed embedded links in multiformatMessage.text

### DIFF
--- a/sarif-2.2/prose/edit/src/file-format-12-multiformatmessagestring-object.md
+++ b/sarif-2.2/prose/edit/src/file-format-12-multiformatmessagestring-object.md
@@ -10,7 +10,7 @@ Certain `multiformatMessageString`-valued properties in this document, for examp
 
 ### text property{#multiformatmessagestring-object--text-property}
 
-A `multiformatMessageString` object **SHALL** contain a property named `text` whose value is a non-empty string containing a plain text representation of the message.
+A `multiformatMessageString` object **SHALL** contain a property named `text` whose value is a non-empty string containing a plain text representation of the message including any links.
 
 > NOTE: This property is required to ensure that the message is viewable even in contexts that do not support the rendering of formatted text.
 

--- a/sarif-2.2/prose/share/sarif-v2.2-draft.html
+++ b/sarif-2.2/prose/share/sarif-v2.2-draft.html
@@ -295,9 +295,7 @@
     }
 
     
-    </style><!--[if lt IE 9]>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
-  <![endif]-->
+    </style>
   </head>
   <body>
     <header id="title-block-header">
@@ -4120,7 +4118,7 @@ index = non negative integer;</code></pre>
           3.12.3 text property <a id='multiformatmessagestring-object--text-property'></a>
         </h3>
         <p>
-          A <code>multiformatMessageString</code> object <strong>SHALL</strong> contain a property named <code>text</code> whose value is a non-empty string containing a plain text representation of the message.
+          A <code>multiformatMessageString</code> object <strong>SHALL</strong> contain a property named <code>text</code> whose value is a non-empty string containing a plain text representation of the message including any links.
         </p>
         <blockquote>
           <p>
@@ -17869,10 +17867,10 @@ lmn\r\n</code></pre>
               <td style="text-align: left;">
                 Incorporate changes from GitHub issue <a href="https://github.com/oasis-tcs/sarif-spec/issues/375">#375</a>, <a href="https://github.com/oasis-tcs/sarif-spec/issues/376">#376</a> (tail), <a href="https://github.com/oasis-tcs/sarif-spec/issues/378">#378</a>, <a href="https://github.com/oasis-tcs/sarif-spec/issues/380">#380</a>,
                 <a href="https://github.com/oasis-tcs/sarif-spec/issues/381">#381</a>, <a href="https://github.com/oasis-tcs/sarif-spec/issues/382">#382</a>, <a href="https://github.com/oasis-tcs/sarif-spec/issues/383">#383</a>, <a href="https://github.com/oasis-tcs/sarif-spec/issues/387">#387</a>, <a href=
-                "https://github.com/oasis-tcs/sarif-spec/issues/389">#389</a>, <a href="https://github.com/oasis-tcs/sarif-spec/issues/390">#<span>https://github.com/oasis-tcs/sarif-spec/issues/390</span></a>, <a href="https://github.com/oasis-tcs/sarif-spec/issues/391">#391</a>, <a href=
-                "https://github.com/oasis-tcs/sarif-spec/issues/392">#392</a>, <a href="https://github.com/oasis-tcs/sarif-spec/issues/393">#393</a>, <a href="https://github.com/oasis-tcs/sarif-spec/issues/396">396</a>, <a href="https://github.com/oasis-tcs/sarif-spec/issues/397">#397</a>, <a href=
-                "https://github.com/oasis-tcs/sarif-spec/issues/399">#399</a>, <a href="https://github.com/oasis-tcs/sarif-spec/issues/401">#401</a>, <a href="https://github.com/oasis-tcs/sarif-spec/issues/402">#402</a>, <a href="https://github.com/oasis-tcs/sarif-spec/issues/403">#403</a>, and <a href=
-                "https://github.com/oasis-tcs/sarif-spec/issues/404">#404</a>.
+                "https://github.com/oasis-tcs/sarif-spec/issues/389">#389</a>, [#<a href="https://github.com/oasis-tcs/sarif-spec/issues/390](https://github.com/oasis-tcs/sarif-spec/issues/390)">https://github.com/oasis-tcs/sarif-spec/issues/390](https://github.com/oasis-tcs/sarif-spec/issues/390)</a>, <a href=
+                "https://github.com/oasis-tcs/sarif-spec/issues/391">#391</a>, <a href="https://github.com/oasis-tcs/sarif-spec/issues/392">#392</a>, <a href="https://github.com/oasis-tcs/sarif-spec/issues/393">#393</a>, <a href="https://github.com/oasis-tcs/sarif-spec/issues/396">396</a>, <a href=
+                "https://github.com/oasis-tcs/sarif-spec/issues/397">#397</a>, <a href="https://github.com/oasis-tcs/sarif-spec/issues/399">#399</a>, <a href="https://github.com/oasis-tcs/sarif-spec/issues/401">#401</a>, <a href="https://github.com/oasis-tcs/sarif-spec/issues/402">#402</a>, <a href=
+                "https://github.com/oasis-tcs/sarif-spec/issues/403">#403</a>, and <a href="https://github.com/oasis-tcs/sarif-spec/issues/404">#404</a>.
               </td>
             </tr>
             <tr class="even">
@@ -18002,9 +18000,10 @@ lmn\r\n</code></pre>
             </tr>
           </tbody>
         </table>
-        <aside id="footnotes" class="footnotes footnotes-end-of-document" role="doc-endnotes">
+        <section id="footnotes" class="footnotes footnotes-end-of-document" role="doc-endnotes">
           <hr />
           <ol>
             <li id="fn1">
               <p>
-                Pronounced 'sæ-rɪf ("a" as in "cat", "i" as in "if", emphasis on the first syllable).<a href="#fnref1" class="footnote-back" role="doc-ba
+                Pronounced 'sæ-rɪf ("a" as in "cat", "i" as in "if", emphasis on the first syllable).<a href="#fnref1" class="footnote-back" role="doc-backlink">↩︎</a>
+ 

--- a/sarif-2.2/prose/share/sarif-v2.2-draft.md
+++ b/sarif-2.2/prose/share/sarif-v2.2-draft.md
@@ -1956,7 +1956,7 @@ Certain `multiformatMessageString`-valued properties in this document, for examp
 
 ### 3.12.3 text property <a id='multiformatmessagestring-object--text-property'></a>
 
-A `multiformatMessageString` object **SHALL** contain a property named `text` whose value is a non-empty string containing a plain text representation of the message.
+A `multiformatMessageString` object **SHALL** contain a property named `text` whose value is a non-empty string containing a plain text representation of the message including any links.
 
 > NOTE: This property is required to ensure that the message is viewable even in contexts that do not support the rendering of formatted text.
 


### PR DESCRIPTION
- [x] implemented agreed proposal of issue #471
- [x] ready for review
- [x] Added user facing delivery items in markdown and html format
- [x] to be approved by the TC

Notes:
- You can inspect the change while this PR is not merged in the source branch e.g. at
  section [3.12.3 text property](https://github.com/oasis-tcs/sarif-spec/blob/proposal-471-allow-embedded-links-in-multiformat-message/sarif-2.2/prose/share/sarif-v2.2-draft.md#multiformatmessagestring-object--text-property)
- This is a first editorial pull request and I did not update the metadata of the document
  to keep the change set as small as possible (date on title page etc. unchanged)