### PR TITLE
Fix typo in XML example of logical locations (#669)

### DIFF
--- a/sarif-2.2/prose/edit/src/file-format-33-logicallocation-object.md
+++ b/sarif-2.2/prose/edit/src/file-format-33-logicallocation-object.md
@@ -259,7 +259,7 @@ Although the values suggested here are useful in the specified categories (for e
 >     },
 >     {
 >       "name": "text",
->       "fullyQualifiedName": "/orders/order[1]/text()",
+>       "fullyQualifiedName": "/orders/order[1]/total/text()",
 >       "kind": "text",
 >       "parentIndex": 1
 >     }


### PR DESCRIPTION
Fix the value of the "fullyQualifiedName" in the cached logical location in the run to equal that within the result.