### PR TITLE
Provided prose explaining the use of guids

### DIFF
--- a/meeting_minutes/250515_SARIF_TC_99.md
+++ b/meeting_minutes/250515_SARIF_TC_99.md
@@ -1,0 +1,228 @@
+ 1. Opening Activities
+
+## 1.1 Opening comments (Co-Chair David)
+
+## 1.2 Introduction of participants/roll call (Co-Chair David)
+
+Quorum requires participation of four or more of the seven voting members.
+
+| First Name | Last Name     | Company             | Role(s)                   | Present |
+|:-----------|:--------------|:--------------------|:--------------------------|:--------|
+| Aditya     | Sharad        | Microsoft           | Voting Member             | NO      |
+| Alexandre  | Dulaunoy      | CIRCL               | Member                    | NO      |
+| Andras     | Iklody        | CIRCL               | Member                    | NO      |
+| Arjun      | Gopalakrishna | Microsoft           | Member                    | NO      |
+| Charles    | Wilson        | Torc Robotics, Inc. | Voting Member             | YES     |
+| Chris      | Meyer         | Microsoft           | Member                    | NO      |
+| David      | Keaton        | Individual          | Co-Chair                  | YES     |
+| David      | Malcolm       | Red Hat             | Voting Member             | YES     |
+| Eddy       | Nakamura      | Microsoft           | Member                    | NO      |
+| Kevin      | Greene        | Mitre Corporation   | Member                    | NO      |
+| Luke       | Cartey        | Microsoft           | Member                    | NO      |
+| Mary       | Martin        | Microsoft           | Member                    | NO      |
+| Michael    | Fanning       | Microsoft           | Member (leave of absence) | NO      |
+| Michael    | Omokoh        | Microsoft           | Voting Member             | YES     |
+| Nathan     | Baird         | Microsoft           | Voting Member             | NO      |
+| Paul       | Brookes       | Microsoft           | Member                    | NO      |
+| Paul       | Seay          | Northrop Grumman    | Member                    | NO      |
+| Ross       | Wollman       | Microsoft           | Member                    | NO      |
+| Stefan     | Hagen         | Individual          | Co-Chair, taking notes    | YES     |
+| Thanassis  | Avgerinos     | ForAllSecure Inc    | Voter (leave of absence)  | NO      |
+| Tim        | Hudson        | Cryptsoft Pty Ltd.  | Member                    | NO      |
+| Vadim      | Okun          | NIST                | Observer                  | NO      |
+
+Five of the seven voting members present - quorum was reached.
+
+The meeting does count against voting rights.
+
+Notes:
+
+- Aditya Sharad sent regrets before the meeting
+
+## 1.3 Procedures for this meeting (Co-Chair David)
+
+## 1.4 Approval of agenda (Co-Chair David)
+
+- [Agenda for May 15, 2025](https://www.oasis-open.org/committees/download.php/72818/)
+
+Agenda was approved.
+
+## 1.5 Approval of previous minutes (Co-Chair David)
+
+- [Minutes of 2025-04-10 Meeting #98](https://www.oasis-open.org/committees/download.php/72699/)
+
+Minutes were approved.
+
+## 1.6 Review of action items and resolutions (Co-Chair Stefan)
+
+- ACTION on Aditya to provide an informal text to guide escaping of URIs.
+  - ONGOING
+- ACTION on David Malcolm to propose text for issue [location.id within a notification object #540](https://github.com/oasis-tcs/sarif-spec/issues/540).
+  - ONGOING
+- ACTION on Stefan to try to propose text in context for [Consider using the "relevant to understanding the result" wording also in notifications/relatedLocation #649](https://github.com/oasis-tcs/sarif-spec/issues/649).
+  - ONGOING
+- ACTION on everyone to provide feedback on the SARIF TC Charter Clarification for 
+  4-year charter reaffirmation process [Draft](https://www.oasis-open.org/committees/download.php/72706/) before the next meeting
+  - DONE
+- ACTION on Stefan to close issue [Double file extensions cannot easily be implemented (nginx, Apache httpd2, Windows)#683](https://github.com/oasis-tcs/sarif-spec/issues/683) without action
+  - DONE
+- ACTION on Stefan to extend the proposal on [Add normative statement against case variation of required keys #681](https://github.com/oasis-tcs/sarif-spec/issues/681)
+  - ONGOING
+- ACTION on Stefan to merge [Update Future.md #622](https://github.com/oasis-tcs/sarif-spec/pull/622) as agreed
+  - DONE
+- ACTION on Stefan to close [futures addition #621](https://github.com/oasis-tcs/sarif-spec/pull/621) without merge
+  - DONE
+
+## 1.7 Identification of SARIF TC voting members (Co-Chair David)
+
+### 1.7.1 Prospective voting members attending their first meeting
+
+### 1.7.2 Members attaining voting rights at the end of this meeting
+
+### 1.7.3 Members losing voting rights if they have not joined this meeting by the time it ends
+
+### 1.7.4 Members who previously lost voting rights who are attending this meeting
+
+### 1.7.5 Members who have declared a leave of absence
+
+# 2. Future Meetings
+
+## 2.1 Future meeting schedule (Co-Chair David)
+
+- Scheduled Teleconference (Thursday at 08:00 PT / 15:00 UTC for 1.5 hours)
+  ```
+  June 12, 2025 
+  ```
+- Proposed Teleconference (Thursday at 08:00 PT / 15:00 UTC for 1.5 hours)
+  ```
+  July 10, 2025
+  ```
+
+# 3. Discussion
+
+## 3.1 SARIF TC Charter Clarification for 4-year charter reaffirmation process [Draft](https://www.oasis-open.org/committees/download.php/72706/)
+
+> The draft proposal for a charter clarification was introduced in the April meeting.
+> Now, we will discuss whether to modify or take action on it.
+> For reference, here is the OASIS process for charter clarification.
+
+- Co-Chair David walks all tot he tlatest changes from short after the previous meeting
+- All are aware and in favor.
+- Co-Chair David informs about the next steps which will be a full majority vote first
+  and if that pases, the draft is submitted to OASIS which will hold a special majority
+  vote and if that succeeds the new charter will be put in effect.
+- Stefan moves to hold a full majority note and kindly request the officers of the TC to
+  collaborate with OASIS administration to initiate a special majority vote on the charter 
+  update at https://www.oasis-open.org/committees/download.php/72706/
+- Full majority vote (with options YES, NO, or ABSTAIN):
+  - Charles Wilson YES
+  - David Keaton YES
+  - David Malcolm YES
+  - Michael Omokoh YES
+  - Stefan Hagen YES
+- Co-Chair David summarizes the result: 
+  - 5 YES
+  - 0 NO
+  - 0 ABSTAIN
+- Co-Chair David states that the full majority vote succeeds as 5 YES are the full majority 
+  of the 7 voting members in total of the TC
+
+## 3.2 Review current state of ecosystem ongoing work
+
+### 3.2.1 Related activities (OPENSSF, etc.)
+
+None
+
+### 3.2.2 Other Ecosystem Items
+
+- David Malcolm: [GCC 15 released last month with SARIF improvements](https://gcc.gnu.org/gcc-15/changes.html#sarif)
+- Stefan: The tool verilate (Linter for SuperVerilog as specified in IEEE 1800-2017) offers SARIF as
+  report format as indicated by [artifact.sourceLanguage property for SystemVerilog #687](https://github.com/oasis-tcs/sarif-spec/issues/687)
+  - David Malcolm: we should add the tool to the wiki page at
+    https://github.com/oasis-tcs/sarif-spec/wiki/Known-Producers-and-Consumers 
+
+## 3.3 Review outcomes of subgroup discussions
+
+- No editor meeting and no new editor revision for this month.
+- No other subgroup discussions.
+
+## 3.4 Discuss the list of small non-breaking changes for SARIF v2.2
+
+### 3.4.1 Editor's report
+
+- Created change-set to add SuperVerilog to example languages in appendix J:
+  - [Added artifact.sourceLanguage property for SystemVerilog (#687) #688](https://github.com/oasis-tcs/sarif-spec/pull/688)
+    - The reporter Wilson Snyder (@wsnyder) of 
+      issue [artifact.sourceLanguage property for SystemVerilog #687](https://github.com/oasis-tcs/sarif-spec/issues/687)
+      thanked us for the prompt consideration and implementation.
+    - the editors kindly request approval by the members of the TC to merge
+      into the SARIF v2.2 spec candidate.
+- The editors suggest to add sarif to the language examples in that appendix J too.
+  - This to implement the issue
+    [artifact.sourceLanguage property (§3.24.10) for SARIF itself #654](https://github.com/oasis-tcs/sarif-spec/issues/654) reported by our own 
+    David Malcolm.
+- Amended issue on investigation of future use of information modeling to become more independent of JSON
+  - [Investigate information modeling for future SARIF #680](https://github.com/oasis-tcs/sarif-spec/issues/680)
+
+### 3.4.2 Approval of changes
+
+Change-Set [Added artifact.sourceLanguage property for SystemVerilog (#687) #688](https://github.com/oasis-tcs/sarif-spec/pull/688)
+- Stefan moves to approve and merge into main
+  - Michael Omokoh seconds.
+    - No objections, no further discussions, and unanimous consent.
+      - The motion carries.
+
+### 3.4.3 Additional discussion
+
+Issue [How to Convert Json value into Sarif format #660](https://github.com/oasis-tcs/sarif-spec/issues/660)
+- Stefan moves to close as answered
+  - David Malcolm seconds.
+    - No objections, no further discussions, and unanimous consent.
+      - The motion carries.
+
+Issue ["Progressive" or "dynamic" SARIF #661](https://github.com/oasis-tcs/sarif-spec/issues/661)
+- Stefan moves to tag with 3.0 label and amends that this means 3.0 or later
+  - David Malcolm seconds.
+    - No objections, no further discussions, and unanimous consent.
+      - The motion carries.
+
+## 3.5 Review Roadmap [Future.md](https://github.com/oasis-tcs/sarif-spec/blob/main/Future.md)
+
+None
+
+## 3.6 Discuss SARIF's relationship to other relevant standards
+
+None
+
+# 4. Other Business
+
+None
+
+# 5. Resolutions and Decisions reached (by 10 minutes prior to scheduled meeting end)
+
+## 5.1 End debate of other issues by 10 minutes prior to scheduled meeting end and follow the agenda from this point (Co-Chair David)
+
+## 5.2 Review of Decisions Reached (Co-Chair Stefan)
+
+- DECISION to meet next after the June meeting on July 10 as the monthly July meeting
+- DECISION to accept the new charter draft at https://www.oasis-open.org/committees/download.php/72706/ and
+  request a special majority vote on the new charter from OASIS
+
+## 5.3 Review of Action Items (Co-Chair Stefan)
+
+- Ongoing ACTIONS (from former meetings):
+  - ACTION on Aditya to provide an informal text to guide escaping of URIs.
+  - ACTION on David Malcolm to propose text for issue [location.id within a notification object #540](https://github.com/oasis-tcs/sarif-spec/issues/540).
+  - ACTION on Stefan to try to propose text in context for [Consider using the "relevant to understanding the result" wording also in notifications/relatedLocation #649](https://github.com/oasis-tcs/sarif-spec/issues/649).
+  - ACTION on Stefan to extend the proposal on [Add normative statement against case variation of required keys #681](https://github.com/oasis-tcs/sarif-spec/issues/681)
+- ACTION on Co-Chair David to request a special majority vote on the new charter from OASIS
+
+# 7. Next Meeting
+
+  ```
+  June 12, 2025
+  ```
+
+# 8. Adjournment
+
+Meeting adjourned.

--- a/sarif-2.2/prose/edit/src/file-format-05-string-properties.md
+++ b/sarif-2.2/prose/edit/src/file-format-05-string-properties.md
@@ -22,6 +22,16 @@ The description of every GUID-valued property will state that it is GUID-valued.
 
 > NOTE 2: In the examples, the values shown for GUID-valued properties are valid GUIDs. In some cases, they are illustrative values such as `"11111111-1111-1111-8888-111111111111"` which are intended to make it easy to identify situations where two GUIDs in the same example are required to be the same. In these illustrative values, the third and fourth component are always `"1111-8888"`, a sample value that conforms to the restrictions on the values of those components.
 
+The same `guid` value on the root elements of two or more SARIF files indicates that the information content MUST be the same.
+
+> NOTE 3: Hashing of text based formats is ambiguous for duplicate detection as the line ending conventions differ and impact the hash.
+
+> Examples of possible duplication sources are: File copies, stored byte streams.
+
+Differing `guid` values on the root elements of two or more SARIF files indicate that the files are different.
+
+> Examples are reports from different nodes on the same system under test using identical tools or a retest run.
+
 ### Hierarchical strings
 
 #### General{#hierarchical-strings--general}

--- a/sarif-2.2/prose/edit/src/file-format-05-string-properties.md
+++ b/sarif-2.2/prose/edit/src/file-format-05-string-properties.md
@@ -31,7 +31,7 @@ The description of every GUID-valued property will state that it is GUID-valued.
 > In these illustrative values, the third and fourth component are always `"1111-8888"`,
 > a sample value that conforms to the restrictions on the values of those components.
 
-The same `guid` value on the root elements of two or more SARIF files indicates that the information content MUST be the same.
+The same `guid` value on the root elements of two or more SARIF files indicates that the information content is the same.
 
 > NOTE 3: Hashing of text based formats is ambiguous for duplicate detection as the line ending conventions differ and impact the hash.
 

--- a/sarif-2.2/prose/edit/src/file-format-05-string-properties.md
+++ b/sarif-2.2/prose/edit/src/file-format-05-string-properties.md
@@ -6,21 +6,30 @@ Certain string-valued properties in this document, for example, `toolComponent.n
 
 ### Redactable strings
 
-Certain string-valued properties in this document (for example, `invocation.commandLine` ([sec](#commandline-property))) might contain sensitive information that a SARIF producer or a SARIF post-processor might choose to redact. We describe these properties as "redactable." The description of every redactable property will state that it is redactable.
+Certain string-valued properties in this document (for example, `invocation.commandLine` ([sec](#commandline-property))) might contain
+sensitive information that a SARIF producer or a SARIF post-processor might choose to redact.
+We describe these properties as "redactable." The description of every redactable property will state that it is redactable.
 
-If a SARIF producer or a SARIF post-processor chooses to redact sensitive information in a redactable property, it **SHALL** replace the sensitive information with a string whose value is an element of `theRun.redactionTokens` ([sec](#redactiontokens-property)).
+If a SARIF producer or a SARIF post-processor chooses to redact sensitive information in a redactable property,
+it **SHALL** replace the sensitive information with a string whose value is an element of `theRun.redactionTokens` ([sec](#redactiontokens-property)).
 
 ### GUID-valued strings
 
-Certain string-valued properties in this document provide unique stable identifiers in the form of a GUID or UUID [cite](#RFC4122). This document uses the term "GUID".
+Certain string-valued properties in this document provide unique stable identifiers in the form of a GUID or UUID [cite](#RFC4122).
+This document uses the term "GUID".
 
 > EXAMPLE 1: `"f81d4fae-7dec-11d0-a765-00a0c91e6bf6"`
 
-> NOTE 1: The UUID standard [cite](#RFC4122) allows hex digits in either upper or lower case. It does not permit delimiters such as curly braces (`"{"`, `"}"`) around the value.
+> NOTE 1: The UUID standard [cite](#RFC4122) allows hex digits in either upper or lower case.
+> It does not permit delimiters such as curly braces (`"{"`, `"}"`) around the value.
 
 The description of every GUID-valued property will state that it is GUID-valued.
 
-> NOTE 2: In the examples, the values shown for GUID-valued properties are valid GUIDs. In some cases, they are illustrative values such as `"11111111-1111-1111-8888-111111111111"` which are intended to make it easy to identify situations where two GUIDs in the same example are required to be the same. In these illustrative values, the third and fourth component are always `"1111-8888"`, a sample value that conforms to the restrictions on the values of those components.
+> NOTE 2: In the examples, the values shown for GUID-valued properties are valid GUIDs.
+> In some cases, they are illustrative values such as `"11111111-1111-1111-8888-111111111111"`
+> which are intended to make it easy to identify situations where two GUIDs in the same example are required to be the same.
+> In these illustrative values, the third and fourth component are always `"1111-8888"`,
+> a sample value that conforms to the restrictions on the values of those components.
 
 The same `guid` value on the root elements of two or more SARIF files indicates that the information content MUST be the same.
 
@@ -36,7 +45,10 @@ Differing `guid` values on the root elements of two or more SARIF files indicate
 
 #### General{#hierarchical-strings--general}
 
-Certain string-valued properties and certain property names in this document (for example, the value of the `runAutomationDetails.id` property ([sec](#runautomationdetails-object--id-property)), and the property names in a property bag ([sec](#property-bags))) are said to be "hierarchical." This means that the string consists of a sequence of forward-slash-separated components, with this syntax:
+Certain string-valued properties and certain property names in this document
+(for example, the value of the `runAutomationDetails.id` property ([sec](#runautomationdetails-object--id-property)),
+and the property names in a property bag ([sec](#property-bags))) are said to be "hierarchical."
+This means that the string consists of a sequence of forward-slash-separated components, with this syntax:
 
 ```
 hierarchical string = component, { "/", component };
@@ -46,21 +58,29 @@ component = { component character };
 component character = ? JSON string character ? - "/";
 ```
 
-> NOTE 1: The grammar prohibits a `component` from containing a forward slash. There is no escape mechanism to allow a `component` to include a forward slash.
+> NOTE 1: The grammar prohibits a `component` from containing a forward slash.
+> There is no escape mechanism to allow a `component` to include a forward slash.
 
 For examples, see [sec](#tags) and [sec](#runautomationdetails-object--id-property).
 
 The description of every hierarchical string will state that it is hierarchical.
 
-A SARIF consumer **SHALL** interpret the values of a hierarchical string as forming a logical hierarchy. The first component represents the top level of the hierarchy, the second component represents the second level, and so on.
+A SARIF consumer **SHALL** interpret the values of a hierarchical string as forming a logical hierarchy.
+The first component represents the top level of the hierarchy, the second component represents the second level, and so on.
 
-> NOTE 2: A hierarchical string does not need to include any forward slashes. The syntax permits a single string of non-forward-slash characters. The purpose of this section is to define the semantics of the forward slash character in those properties that respect it.
+> NOTE 2: A hierarchical string does not need to include any forward slashes.
+> The syntax permits a single string of non-forward-slash characters.
+> The purpose of this section is to define the semantics of the forward slash character in those properties that respect it.
 
-In string-valued properties and property names that are *not* described as hierarchical, the forward slash character has no special meaning, and a SARIF consumer **SHALL NOT** interpret it as dividing the value into hierarchical components.
+In string-valued properties and property names that are *not* described as hierarchical,
+the forward slash character has no special meaning,
+and a SARIF consumer **SHALL NOT** interpret it as dividing the value into hierarchical components.
 
 #### Versioned hierarchical strings
 
-Certain hierarchical strings in this document (for example, the property names in `result.fingerprints` ([sec](#fingerprints-property)) and `result.partialFingerprints` ([sec](#partialfingerprints-property))) are said to be "versioned." This means that if the last `component` of the string is of the form
+Certain hierarchical strings in this document
+(for example, the property names in `result.fingerprints` ([sec](#fingerprints-property)) and `result.partialFingerprints` ([sec](#partialfingerprints-property)))
+are said to be "versioned." This means that if the last `component` of the string is of the form
 
     version component = "v", non negative integer;
 
@@ -68,13 +88,18 @@ then a SARIF consumer **SHALL** consider that component to represent the version
 
 The description of every versioned hierarchical string will state that it is versioned.
 
-In string-valued properties and property names that are described as hierarchical but *not* as versioned, a final `component` matching the syntax of `version component` has no special meaning, and a SARIF consumer **SHALL NOT** interpret it as a version number.
+In string-valued properties and property names that are described as hierarchical but *not* as versioned,
+a final `component` matching the syntax of `version component` has no special meaning,
+and a SARIF consumer **SHALL NOT** interpret it as a version number.
 
-> NOTE 1: A versioned hierarchical string does not need to include a version component. The syntax permits but does not require it.
+> NOTE 1: A versioned hierarchical string does not need to include a version component.
+> The syntax permits but does not require it.
 
 A hierarchical string without a version component **SHALL** be considered older than any corresponding string with a version component.
 
-> EXAMPLE 1: In this example, the partial fingerprint whose property name is `"prohibitedWordHash"` is considered to have been computed with an older version of the "prohibited word hash" algorithm than the partial fingerprint whose property name is `"prohibitedWordHash/v1"`.
+> EXAMPLE 1: In this example, the partial fingerprint whose property name is `"prohibitedWordHash"` is considered to
+> have been computed with an older version of the "prohibited word hash" algorithm than the partial fingerprint whose
+> property name is `"prohibitedWordHash/v1"`.
 >
 > ```json
 > {                                 # A result object ((#result-object)).
@@ -85,4 +110,5 @@ A hierarchical string without a version component **SHALL** be considered older 
 > }
 > ```
 
-> NOTE 2: When a previously unversioned string is later versioned, as in the example above, it might be clearer to specify `"v2"` for the first explicitly versioned string.
+> NOTE 2: When a previously unversioned string is later versioned, as in the example above,
+> it might be clearer to specify `"v2"` for the first explicitly versioned string.


### PR DESCRIPTION
Content changes:

- Added normative statement on consequences of same value top-level GUIDs
  for multiple SARIF files
- Added a note on sources for hash divergence when computed over text based formats
  without additional conventions
- Added examples for the source of duplication
- Added soft language on the consequences of multiple SARIF files having
  differing values for top-level GUIds
- Added examples for such possibly non-material differences
- Closes iossue #648 Provide prose explaining the use of guids across all occurrences

Editorial changes:

- Nit: Redistribution of sentence so lines

Closes #648 (Provide prose explaining the use of guids across all occurrences).