### PR TITLE
Enhanced rationale for notification object

### DIFF
--- a/sarif-2.2/prose/edit/src/file-format-58-notification-object.md
+++ b/sarif-2.2/prose/edit/src/file-format-58-notification-object.md
@@ -128,7 +128,7 @@ If the notification is not the result of a runtime exception, the `exception` pr
 
 A `notification` object **MAY** contain a property named `relatedLocations` whose value is
 an array of zero or more unique ([sec](#array-properties-with-unique-values)) `location` objects ([sec](#location-object)) that
-identify those locations relevant to understanding the result.
+identify those locations relevant to understanding the `notification`.
 
 The `relatedLocations` property **SHOULD** allow `notification` objects to distinguish between the following types of locations:
 


### PR DESCRIPTION
Content changes:

- Used the 'relevant to understanding the result' wording also
  in notifications/relatedLocation replacing the rather convoluted and shallow
  'to which the condition described by the notification applies'
- Implements issue 649 Consider using the 'relevant to understanding the result'
  wording also in notifications/relatedLocation

Editorial changes:

- Nit: Redistribution of sentences so lines

Closes #649.