### PR TITLE
Fixed typo in messages with embedded links

### DIFF
--- a/sarif-2.2/prose/edit/src/file-format-11-message-object.md
+++ b/sarif-2.2/prose/edit/src/file-format-11-message-object.md
@@ -129,7 +129,7 @@ Literal square brackets ("`[`" and "`]`") in the link text of a plain text messa
 > EXAMPLE 1: Consider this embedded link whose link text contains square brackets and backslashes:
 >
 >       "message": {
->         "text": "Prohibited term used in [para\\[0\\]\\\\spans\\[2\\](1)."
+>         "text": "Prohibited term used in [para\\[0\\]\\\\spans\\[2\\]](1)."
 >       }
 >
 > A SARIF viewer would render it as follows:


### PR DESCRIPTION
Content changes:

- There was an unescaped closing square bracket missing in the value of the text member
- Fixes issue 656 'Suspected typo in EXAMPLE 1 of 3.11.6 ...'

Closes issue #656.