### PR TITLE
Escaped backslash in 3.11.6 Messages with embedded links

### DIFF
--- a/sarif-2.2/prose/edit/src/file-format-11-message-object.md
+++ b/sarif-2.2/prose/edit/src/file-format-11-message-object.md
@@ -134,7 +134,7 @@ Literal square brackets ("`[`" and "`]`") in the link text of a plain text messa
 >
 > A SARIF viewer would render it as follows:
 >
-> Prohibited term used in para\[0\]\spans\[2\].
+> Prohibited term used in para\[0\]\\spans\[2\].
 
 Literal square brackets and (doubled) backslashes **MAY** appear anywhere else in a plain text message without being escaped.
 


### PR DESCRIPTION
Closes #701: Unescaped backslash in 3.11.6 Messages with embedded links