### PR TITLE
Added semantic title injection to HTML generator chain

### DIFF
--- a/sarif-2.2/prose/edit/bin/toccata.py
+++ b/sarif-2.2/prose/edit/bin/toccata.py
@@ -21,6 +21,10 @@ LOGO_AT = pathlib.Path('..') / 'media' / 'logo-data-url.txt'
 BASE_CSS_AT = pathlib.Path('..') / 'share' / 'style' / 'base.css'
 SKIN_CSS_AT = pathlib.Path('..') / 'share' / 'style' / 'skin.css'
 
+IN_TITLE_TRIGGER_IS = '<title>'
+TITLE_INNER_HTML_MARKER_IS = 'tmp'
+PATCH_TITLE_INNER_HTML = 'Static Analysis Results Interchange Format (SARIF) Version 2.2'
+
 # Type declarations:
 META_TOC_TYPE = dict[str, dict[str, Union[bool, str, list[dict[str, str]]]]]
 SEC_LVL_CNT_TYPE = tuple[int, int, int, int, int, int]
@@ -97,6 +101,8 @@ def main(argv: list[str]) -> int:
     outgoing = []
     in_toc = False
     for line in incoming:
+        if TITLE_INNER_HTML_MARKER_IS in line:
+            line = line.replace(TITLE_INNER_HTML_MARKER_IS, PATCH_TITLE_INNER_HTML)
         if in_toc:
             if line.startswith(INTRO_STARTSWITH_TRIGGER):
                 in_toc = False

--- a/sarif-2.2/prose/edit/bin/toccata.py
+++ b/sarif-2.2/prose/edit/bin/toccata.py
@@ -6,9 +6,13 @@ from typing import Union
 
 ENCODING = 'utf-8'
 NL = '\n'
+SP = ' '
 COLON = ':'
 DASH = '-'
 DOT = '.'
+
+LANG_PATCH = '<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">'
+LOGO_TARGET = 'https://docs.oasis-open.org/templates/OASISLogo-v3.0.png'
 
 TOC_STARTSWITH_TRIGGER = '<h1 id="table-of-contents'
 INTRO_STARTSWITH_TRIGGER = '<h1 id="1-introduction'
@@ -68,7 +72,7 @@ def generate_toc(toc_db: list[TOC_ENTRY_TYPE]) -> str:
         if pres > past:
             patch_me = entries[slot - 1]
             there = len('</li>')
-            entries[slot - 1] = patch_me[:-there] + f'<ul>'
+            entries[slot - 1] = patch_me[:-there] + '<ul>'
             entries.append(f'<li>{num_disp} <a href="#{slug}">{text}</a></li>')
             past = pres
             continue
@@ -95,6 +99,14 @@ def main(argv: list[str]) -> int:
     # print(toc_db[-1])
     the_toc = generate_toc(toc_db)
     # print(the_toc)
+
+    with open('../share/style/base.css', 'rt', encoding=ENCODING) as handle:
+        base_css = handle.read()
+    with open('../share/style/skin.css', 'rt', encoding=ENCODING) as handle:
+        skin_css = handle.read()
+    with open(LOGO_AT, 'rt', encoding=ENCODING) as handle:
+        logo_data = handle.read().strip()
+
     with open('build/tmp.html', 'rt', encoding=ENCODING) as handle:
         incoming = handle.readlines()
 
@@ -117,6 +129,18 @@ def main(argv: list[str]) -> int:
             continue
         if '<component>' in line:
             line = line.replace('<component>', '&lt;conponent>')
+
+        if line.startswith('<html xmlns'):
+            line = LANG_PATCH
+        elif '</style>' in line:
+            line = NL + base_css + NL + skin_css + NL + line
+        elif 'style/base.css' in line:
+            continue
+        elif 'style/skin.css' in line:
+            continue
+        elif LOGO_TARGET in line:
+            line = line.replace(LOGO_TARGET, logo_data)
+
         outgoing.append(line)
 
     with open('build/injected.html', 'wt', encoding=ENCODING) as handle:


### PR DESCRIPTION
- Closes #710

In addition (tool and format correctness concerns):

- adds language values (HTML semantics)
- internalizes base and skin css files (standalone HTML file)
- internalizes logo file (standalone HTML file)
- fixes an f-string without placeholder in generator (python)
- fixed typo in component escaped repülacement
- added developer documentation (comments)

Tested by comparing results before and after code changes.
