### PR TITLE
Updated version value of example 1 extracted from section 3.3.4

### DIFF
--- a/sarif-2.2/example/example-3-3-4-01.json
+++ b/sarif-2.2/example/example-3-3-4-01.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.0",
+  "version": "2.2",
   "runs": [
     {
       "tool": {
@@ -9,17 +9,18 @@
       },
       "results": [
         {
-          "message": {"id": "..."},
-          "locations": [               
-            {                          
-              "physicalLocation": {    
-                "artifactLocation": {  
+          "message": {
+            "id": "..."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
                   "uri": "ui/window.c",
                   "uriBaseId": "SRCROOT"
                 },
-         
-                "region": {            
-                  "startLine": 42      
+                "region": {
+                  "startLine": 42
                 }
               }
             }


### PR DESCRIPTION
This change-set implements the issue #721 in the (historical) example location:

1. /sarif-2.2/example/example-3-3-4-01.json

Closes #721

Test:

Validity in location 1:

```console
❯ check-jsonschema --schemafile ${schema} ${instance} --verbose
ok -- validation done
The following files were checked:
  example/example-3-3-4-01.json
```
