### PR TITLE
Add `securitySeverity` property to `result` and `reportingDescriptor`

### DIFF
--- a/sarif-2.2/prose/edit/src/file-format-27-result-object.md
+++ b/sarif-2.2/prose/edit/src/file-format-27-result-object.md
@@ -785,6 +785,17 @@ If `precision` is absent on a `result` object, and `theDescriptor` exists and sp
 
 > NOTE: `precision` values are in general only commensurable when they refer to results of the same rule from the same tool, or equivalent rules from different tools. In an engineering system that aggregates results from multiple tools, precision values might need to be adjusted, either automatically or by end users, so that precision values from different tools can be interleaved in a meaningful way.
 
+### `securitySeverity` Property{#result-object--securityseverity-property}
+
+A `result` object **MAY** contain a property named `securitySeverity` whose value is a number between `0.0` and `100.0` inclusive, representing a numerical estimate of the impact or exploitability of this result on the security of the analyzed system. `0.0` is the lowest severity and `100.0` is the highest severity.
+
+If `securitySeverity` is absent on a `result` object, and `theDescriptor` exists and specifies a `securitySeverity` property ([sec](#reportingdescriptor-object--securityseverity-property)), the `securitySeverity` of the result is inherited from `theDescriptor`.
+
+> NOTE: `securitySeverity` values are in general only commensurable when they refer to results of the same rule from the same tool, or equivalent rules from different tools. In an engineering system that aggregates results from multiple tools, securitySeverity values might need to be adjusted, either automatically or by end users, so that securitySeverity values from different tools can be interleaved in a meaningful way.
+
+> NOTE: To make `securitySeverity` values easier to compare between different results and rules, a tool may set the value by aggregating external metrics for security severity, such as Exploit Prediction Scoring System (EPSS) scores, for security vulnerabilities identified by similar results and rules.
+
+
 ### `attachments` Property
 
 A `result` object **MAY** contain a property named `attachments` whose value is an array of zero or more unique ([sec](#array-properties-with-unique-values)) `attachment` objects ([sec](#attachment-object)) each of which describes an artifact relevant to the detection of the result.

--- a/sarif-2.2/prose/edit/src/file-format-27-result-object.md
+++ b/sarif-2.2/prose/edit/src/file-format-27-result-object.md
@@ -791,7 +791,7 @@ A `result` object **MAY** contain a property named `securitySeverity` whose valu
 
 If `securitySeverity` is absent on a `result` object, and `theDescriptor` exists and specifies a `securitySeverity` property ([sec](#reportingdescriptor-object--securityseverity-property)), the `securitySeverity` of the result is inherited from `theDescriptor`.
 
-> NOTE: `securitySeverity` values are in general only commensurable when they refer to results of the same rule from the same tool, or equivalent rules from different tools. In an engineering system that aggregates results from multiple tools, securitySeverity values might need to be adjusted, either automatically or by end users, so that securitySeverity values from different tools can be interleaved in a meaningful way.
+> NOTE: `securitySeverity` values are in general only commensurable when they refer to results of the same rule from the same tool, or equivalent rules from different tools. In an engineering system that aggregates results from multiple tools, `securitySeverity` values might need to be adjusted, either automatically or by end users, so that `securitySeverity` values from different tools can be interleaved in a meaningful way.
 
 > NOTE: To make `securitySeverity` values easier to compare between different results and rules, a tool may set the value by aggregating external metrics for security severity, such as the Common Vulnerability Scoring System (CVSS) (<https://www.first.org/cvss>) scores, for security vulnerabilities identified by similar results and rules.
 

--- a/sarif-2.2/prose/edit/src/file-format-27-result-object.md
+++ b/sarif-2.2/prose/edit/src/file-format-27-result-object.md
@@ -787,14 +787,13 @@ If `precision` is absent on a `result` object, and `theDescriptor` exists and sp
 
 ### `securitySeverity` Property{#result-object--securityseverity-property}
 
-A `result` object **MAY** contain a property named `securitySeverity` whose value is a number between `0.0` and `100.0` inclusive, representing a numerical estimate of the impact or exploitability of this result on the security of the analyzed system. `0.0` is the lowest severity and `100.0` is the highest severity.
+A `result` object **MAY** contain a property named `securitySeverity` whose value is a number between `0.0` and `100.0` inclusive, representing a numerical estimate of the severity of the class of vulnerabilities found by this result. `0.0` is the lowest severity and `100.0` is the highest severity.
 
 If `securitySeverity` is absent on a `result` object, and `theDescriptor` exists and specifies a `securitySeverity` property ([sec](#reportingdescriptor-object--securityseverity-property)), the `securitySeverity` of the result is inherited from `theDescriptor`.
 
 > NOTE: `securitySeverity` values are in general only commensurable when they refer to results of the same rule from the same tool, or equivalent rules from different tools. In an engineering system that aggregates results from multiple tools, securitySeverity values might need to be adjusted, either automatically or by end users, so that securitySeverity values from different tools can be interleaved in a meaningful way.
 
-> NOTE: To make `securitySeverity` values easier to compare between different results and rules, a tool may set the value by aggregating external metrics for security severity, such as Exploit Prediction Scoring System (EPSS) scores, for security vulnerabilities identified by similar results and rules.
-
+> NOTE: To make `securitySeverity` values easier to compare between different results and rules, a tool may set the value by aggregating external metrics for security severity, such as the Common Vulnerability Scoring System (CVSS) (<https://www.first.org/cvss>) scores, for security vulnerabilities identified by similar results and rules.
 
 ### `attachments` Property
 

--- a/sarif-2.2/prose/edit/src/file-format-27-result-object.md
+++ b/sarif-2.2/prose/edit/src/file-format-27-result-object.md
@@ -787,7 +787,7 @@ If `precision` is absent on a `result` object, and `theDescriptor` exists and sp
 
 ### `securitySeverity` Property{#result-object--securityseverity-property}
 
-A `result` object **MAY** contain a property named `securitySeverity` whose value is a number between `0.0` and `100.0` inclusive, representing a numerical estimate of the severity of the class of vulnerabilities found by this result. `0.0` is the lowest severity and `100.0` is the highest severity.
+A `result` object **MAY** contain a property named `securitySeverity` whose value is a number between `0.0` and `100.0` inclusive, representing a numerical estimate of the severity of the class of vulnerabilities found by this result. This value **MAY** be represented as a floating-point number. `0.0` is the lowest severity and `100.0` is the highest severity.
 
 If `securitySeverity` is absent on a `result` object, and `theDescriptor` exists and specifies a `securitySeverity` property ([sec](#reportingdescriptor-object--securityseverity-property)), the `securitySeverity` of the result is inherited from `theDescriptor`.
 

--- a/sarif-2.2/prose/edit/src/file-format-49-reportingdescriptor-object.md
+++ b/sarif-2.2/prose/edit/src/file-format-49-reportingdescriptor-object.md
@@ -252,6 +252,18 @@ If `precision` is present, it acts as the value of `result.precision` ([sec](#re
 
 > NOTE: `precision` values are in general only commensurable when they refer to results of the same rule from the same tool, or equivalent rules from different tools. In an engineering system that aggregates results from multiple tools, precision values might need to be adjusted, either automatically or by end users, so that precision values from different tools can be interleaved in a meaningful way.
 
+### `securitySeverity` Property{#reportingdescriptor-object--securityseverity-property}
+
+A `reportingDescriptor` object that describes a rule **MAY** contain a property named `securitySeverity` whose value is a number between `0.0` and `100.0` inclusive, representing a numerical estimate of the impact or exploitability of results produced by the rule on the security of the analyzed system. `0.0` is the lowest severity and `100.0` is the highest severity.
+
+If `securitySeverity` is present, it acts as the value of `result.securitySeverity` ([sec](#result-object--securityseverity-property)) for any `result` object ([sec](#result-object)) whose `ruleIndex` ([sec](#ruleindex-property)) or `rule` property ([sec](#rule-property)), either explicitly supplied or inferred from its default, references this `reportingDescriptor`, and which does not itself specify a `securitySeverity` property.
+
+`securitySeverity` is not applicable to notifications.
+
+> NOTE: `securitySeverity` values are in general only commensurable when they refer to results of the same rule from the same tool, or equivalent rules from different tools. In an engineering system that aggregates results from multiple tools, securitySeverity values might need to be adjusted, either automatically or by end users, so that securitySeverity values from different tools can be interleaved in a meaningful way.
+
+> NOTE: To make `securitySeverity` values easier to compare between different results and rules, a tool may set the value by aggregating external metrics for security severity, such as Exploit Prediction Scoring System (EPSS) scores, for security vulnerabilities identified by similar results and rules.
+
 ### `relationships` Property{#reportingdescriptor-object--relationships-property}
 
 A `reportingDescriptor` object **MAY** contain a property named `relationships` whose value is an array of zero or more unique ([sec](#array-properties-with-unique-values)) `reportingDescriptorRelationship` objects ([sec](#reportingdescriptorrelationship-object)) each of which declares one or more directed relationships from `thisObject` to another `reportingDescriptor` object, which we refer to as `theTarget`, specified by `reportingDescriptorRelationship`.`target` ([sec](#reportingdescriptorrelationship-object--target-property)). The natures of the relationships between `thisObject` and `theTarget` are specified by `reportingDescriptorRelationship.kinds` ([sec](#reportingdescriptorrelationship-object--kinds-property)).

--- a/sarif-2.2/prose/edit/src/file-format-49-reportingdescriptor-object.md
+++ b/sarif-2.2/prose/edit/src/file-format-49-reportingdescriptor-object.md
@@ -254,7 +254,7 @@ If `precision` is present, it acts as the value of `result.precision` ([sec](#re
 
 ### `securitySeverity` Property{#reportingdescriptor-object--securityseverity-property}
 
-A `reportingDescriptor` object that describes a rule **MAY** contain a property named `securitySeverity` whose value is a number between `0.0` and `100.0` inclusive, representing a numerical estimate of the impact or exploitability of results produced by the rule on the security of the analyzed system. `0.0` is the lowest severity and `100.0` is the highest severity.
+A `reportingDescriptor` object that describes a rule **MAY** contain a property named `securitySeverity` whose value is a number between `0.0` and `100.0` inclusive, representing a numerical estimate of the severity of the class of vulnerabilities found by results produced by the rule. `0.0` is the lowest severity and `100.0` is the highest severity.
 
 If `securitySeverity` is present, it acts as the value of `result.securitySeverity` ([sec](#result-object--securityseverity-property)) for any `result` object ([sec](#result-object)) whose `ruleIndex` ([sec](#ruleindex-property)) or `rule` property ([sec](#rule-property)), either explicitly supplied or inferred from its default, references this `reportingDescriptor`, and which does not itself specify a `securitySeverity` property.
 
@@ -262,7 +262,7 @@ If `securitySeverity` is present, it acts as the value of `result.securitySeveri
 
 > NOTE: `securitySeverity` values are in general only commensurable when they refer to results of the same rule from the same tool, or equivalent rules from different tools. In an engineering system that aggregates results from multiple tools, securitySeverity values might need to be adjusted, either automatically or by end users, so that securitySeverity values from different tools can be interleaved in a meaningful way.
 
-> NOTE: To make `securitySeverity` values easier to compare between different results and rules, a tool may set the value by aggregating external metrics for security severity, such as Exploit Prediction Scoring System (EPSS) scores, for security vulnerabilities identified by similar results and rules.
+> NOTE: To make `securitySeverity` values easier to compare between different results and rules, a tool may set the value by aggregating external metrics for security severity, such as the Common Vulnerability Scoring System (CVSS) (<https://www.first.org/cvss>) scores, for security vulnerabilities identified by similar results and rules.
 
 ### `relationships` Property{#reportingdescriptor-object--relationships-property}
 

--- a/sarif-2.2/prose/edit/src/file-format-49-reportingdescriptor-object.md
+++ b/sarif-2.2/prose/edit/src/file-format-49-reportingdescriptor-object.md
@@ -260,7 +260,7 @@ If `securitySeverity` is present, it acts as the value of `result.securitySeveri
 
 `securitySeverity` is not applicable to notifications.
 
-> NOTE: `securitySeverity` values are in general only commensurable when they refer to results of the same rule from the same tool, or equivalent rules from different tools. In an engineering system that aggregates results from multiple tools, securitySeverity values might need to be adjusted, either automatically or by end users, so that securitySeverity values from different tools can be interleaved in a meaningful way.
+> NOTE: `securitySeverity` values are in general only commensurable when they refer to results of the same rule from the same tool, or equivalent rules from different tools. In an engineering system that aggregates results from multiple tools, `securitySeverity` values might need to be adjusted, either automatically or by end users, so that `securitySeverity` values from different tools can be interleaved in a meaningful way.
 
 > NOTE: To make `securitySeverity` values easier to compare between different results and rules, a tool may set the value by aggregating external metrics for security severity, such as the Common Vulnerability Scoring System (CVSS) (<https://www.first.org/cvss>) scores, for security vulnerabilities identified by similar results and rules.
 

--- a/sarif-2.2/prose/edit/src/file-format-49-reportingdescriptor-object.md
+++ b/sarif-2.2/prose/edit/src/file-format-49-reportingdescriptor-object.md
@@ -254,7 +254,7 @@ If `precision` is present, it acts as the value of `result.precision` ([sec](#re
 
 ### `securitySeverity` Property{#reportingdescriptor-object--securityseverity-property}
 
-A `reportingDescriptor` object that describes a rule **MAY** contain a property named `securitySeverity` whose value is a number between `0.0` and `100.0` inclusive, representing a numerical estimate of the severity of the class of vulnerabilities found by results produced by the rule. `0.0` is the lowest severity and `100.0` is the highest severity.
+A `reportingDescriptor` object that describes a rule **MAY** contain a property named `securitySeverity` whose value is a number between `0.0` and `100.0` inclusive, representing a numerical estimate of the severity of the class of vulnerabilities found by results produced by the rule. This value **MAY** be represented as a floating-point number. `0.0` is the lowest severity and `100.0` is the highest severity.
 
 If `securitySeverity` is present, it acts as the value of `result.securitySeverity` ([sec](#result-object--securityseverity-property)) for any `result` object ([sec](#result-object)) whose `ruleIndex` ([sec](#ruleindex-property)) or `rule` property ([sec](#rule-property)), either explicitly supplied or inferred from its default, references this `reportingDescriptor`, and which does not itself specify a `securitySeverity` property.
 

--- a/sarif-2.2/schema/sarif.json
+++ b/sarif-2.2/schema/sarif.json
@@ -1744,6 +1744,12 @@
           "minimum": 0.0,
           "maximum": 100.0
         },
+        "securitySeverity": {
+          "description": "A number between 0.0 and 100.0 inclusive, representing the security impact of results produced by the rule.",
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 100.0
+        },
         "properties": {
           "description": "Key/value pairs that provide additional information about the report.",
           "$ref": "#/$defs/propertyBag"
@@ -2037,6 +2043,12 @@
         },
         "precision": {
           "description": "A number between 0.0 and 100.0 inclusive, representing the tool or tool maintainer's confidence that this result is a true positive.",
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 100.0
+        },
+        "securitySeverity": {
+          "description": "A number between 0.0 and 100.0 inclusive, representing the security impact of this result.",
           "type": "number",
           "minimum": 0.0,
           "maximum": 100.0

--- a/sarif-2.2/schema/sarif.json
+++ b/sarif-2.2/schema/sarif.json
@@ -1745,7 +1745,7 @@
           "maximum": 100.0
         },
         "securitySeverity": {
-          "description": "A number between 0.0 and 100.0 inclusive, representing the security impact of results produced by the rule.",
+          "description": "A number between 0.0 and 100.0 inclusive, representing the severity of the class of vulnerabilities found by results produced by the rule.",
           "type": "number",
           "minimum": 0.0,
           "maximum": 100.0
@@ -2048,7 +2048,7 @@
           "maximum": 100.0
         },
         "securitySeverity": {
-          "description": "A number between 0.0 and 100.0 inclusive, representing the security impact of this result.",
+          "description": "A number between 0.0 and 100.0 inclusive, representing the severity of the class of vulnerabilities found by this result.",
           "type": "number",
           "minimum": 0.0,
           "maximum": 100.0


### PR DESCRIPTION
Closes https://github.com/oasis-tcs/sarif-spec/issues/612.
Proposal for SARIF 2.2.

Stacked on #766 to avoid conflicts.